### PR TITLE
Add M1 release binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,9 +125,14 @@ jobs:
             target: x86_64-pc-windows-msvc
             linker_package:
             cc: ""
-          - os: macos-latest
+          - os: macos-intel-latest
             platform: macos-x64
             target: x86_64-apple-darwin
+            linker_package:
+            cc: ""
+          - os: macos-arm64-latest
+            platform: macos-aarch64
+            target: aarch64-apple-darwin
             linker_package:
             cc: ""
 


### PR DESCRIPTION
closes hirosystems/clarity-lsp#39 

This PR is aiming to add support for building for ARM64 MacOS. @lgalabru @CharlieC3 please check this over since I've probably got something wrong here (I don't know where everything is lol).