### PR TITLE
fix: hightighting comments in traits

### DIFF
--- a/editors/code/syntaxes/clarity.tmLanguage.json
+++ b/editors/code/syntaxes/clarity.tmLanguage.json
@@ -123,6 +123,7 @@
           },
           "name": "meta.define-trait-body",
           "patterns": [
+            {"include": "#expression"},
             {
               "begin": "(?x) (\\() \\s* ([a-zA-Z][a-zA-Z0-9_\\-\\!\\?]+\\??) \\s+",
               "end": "(\\))",

--- a/editors/code/syntaxes/clarity.tmLanguage.json
+++ b/editors/code/syntaxes/clarity.tmLanguage.json
@@ -336,6 +336,7 @@
     },
     "data-type": {
       "patterns": [
+        { "include": "#comment" },
         {
           "comment": "numerics",
           "name": "entity.name.type.numeric.clarity",


### PR DESCRIPTION
fix: hirosystems/clarity-lsp#25 