### PR TITLE
feat: add debug support

### DIFF
--- a/editors/code/debug/debug.js
+++ b/editors/code/debug/debug.js
@@ -1,0 +1,10 @@
+const { lookpath } = require("lookpath");
+const { spawn } = require('child_process');
+
+(async () => {
+  const path = await lookpath("clarinet");
+  const dap = spawn(path, ['dap'], {stdio: [process.stdin, process.stdout, process.stderr]});
+  await new Promise( (resolve) => {
+    dap.on('exit', resolve);
+  })
+})();

--- a/editors/code/debug/package-lock.json
+++ b/editors/code/debug/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "debug",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "debug",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "child_process": "^1.0.2",
+        "lookpath": "^1.2.2"
+      }
+    },
+    "node_modules/child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
+    },
+    "node_modules/lookpath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+      "integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q==",
+      "bin": {
+        "lookpath": "bin/lookpath.js"
+      },
+      "engines": {
+        "npm": ">=6.13.4"
+      }
+    }
+  },
+  "dependencies": {
+    "child_process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
+      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
+    },
+    "lookpath": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/lookpath/-/lookpath-1.2.2.tgz",
+      "integrity": "sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q=="
+    }
+  }
+}

--- a/editors/code/debug/package.json
+++ b/editors/code/debug/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "debug",
+  "version": "1.0.0",
+  "description": "",
+  "main": "debug.js",
+  "author": "Brice Dobry <brice@hiro.so>",
+  "license": "ISC",
+  "dependencies": {
+    "child_process": "^1.0.2",
+    "lookpath": "^1.2.2"
+  }
+}

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -154,6 +154,57 @@
                     "default": false
                 }
             }
-        }
+        },
+        "debuggers": [
+            {
+                "type": "clarinet",
+                "label": "Clarinet Debug",
+                "program": "./debug/debug.js",
+                "runtime": "node",
+                "languages": [
+                    "clarity"
+                ],
+                "configurationAttributes": {
+                    "launch": {
+                        "required": [
+                            "manifest",
+                            "expression"
+                        ],
+                        "properties": {
+                            "manifest": {
+                                "type": "string",
+                                "description": "Path to Clarinet.toml."
+                            },
+                            "expression": {
+                                "type": "string",
+                                "description": "Expression to debug."
+                            }
+                        }
+                    }
+                },
+                "initialConfigurations": [
+                    {
+                        "type": "clarinet",
+                        "request": "launch",
+                        "name": "Call .foo.bar",
+                        "manifest": "${workspaceFolder}/Clarinet.toml",
+                        "expression": "(contract-call? .foo bar 42)"
+                    }
+                ],
+                "configurationSnippets": [
+                    {
+                        "label": "Clarinet Debugger",
+                        "description": "A new configuration for debugging a smart contract.",
+                        "body": {
+                            "type": "clarinet",
+                            "request": "launch",
+                            "name": "Call .foo.bar",
+                            "manifest": "${workspaceFolder}/Clarinet.toml",
+                            "expression": "(contract-call? .foo bar 42)"
+                        }
+                    }
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
This commit adds support for debugging within VSCode. `clarinet dap`
implements a DAP server which can interact with VSCode for an
interactive debug session.