### PR TITLE
chore: update extension metadata

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -1,7 +1,7 @@
 {
     "name": "clarity-lsp",
-    "displayName": "Clarity for Visual Studio Code",
-    "description": "Coding assistant for Smart Contracts (Stacks, Bitcoin)",
+    "displayName": "Clarity",
+    "description": "Provides validation, syntax highlighting, code completion, and debugging for Clarity smart contracts",
     "icon": "images/stacks.png",
     "private": true,
     "version": "0.7.1",
@@ -25,14 +25,15 @@
         "color": "#242424",
         "theme": "dark"
     },
-    "qna": "https://clarity-lang.org/",
+    "qna": "https://docs.hiro.so/",
     "categories": [
-        "Programming Languages"
+        "Programming Languages",
+        "Debuggers"
     ],
     "engines": {
         "vscode": "^1.43.0"
     },
-    "enableProposedApi": false,
+    "enabledApiProposals": [],
     "scripts": {
         "vscode:prepublish": "tsc && rollup -c rollup.config.lsp.js && rollup -c rollup.config.dap.js",
         "package": "vsce package -o clarity-lsp.vsix",


### PR DESCRIPTION
I set the qna link to `https://doc.hiro.so` which has docs about clarinet, as well the discord and stacks forum links in the footer.

I also updated the `enableProposedApi` flag which recently changed [(according to VSCode) ](https://code.visualstudio.com/api/advanced-topics/using-proposed-api)

- fixes hirosystems/clarity-lsp#21 
- fixes hirosystems/clarity-lsp#20 
- fixes hirosystems/clarity-lsp#19 