### PR TITLE
fix: enable streaming for in-memory observers

### DIFF
--- a/components/ordhook-core/src/service/predicates.rs
+++ b/components/ordhook-core/src/service/predicates.rs
@@ -219,7 +219,8 @@ pub fn create_and_consolidate_chainhook_config_with_predicates(
             ),
             predicate,
         ) {
-            Ok(spec) => {
+            Ok(ref mut spec) => {
+                chainhook_config.enable_specification(spec);
                 info!(
                     ctx.expect_logger(),
                     "Predicate {} retrieved from config and loaded",


### PR DESCRIPTION
Fix streaming when the observer is being passed in line - so like:
```console
ordhook start service --post-to=http://webhook.site
```
