### PR TITLE
CI: Enable CodeCov for Ordhook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,11 @@ jobs:
           rustup update
           RUST_BACKTRACE=1 cargo test --all -- --test-threads=1
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build-publish:
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Upload tests to CodeCove. [Related Issue](https://github.com/hirosystems/devops/issues/1358).