### PR TITLE
refactor: revisit `delete_data_in_ordhook_db`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.2.1](https://github.com/hirosystems/ordhook/compare/v2.2.0...v2.2.1) (2024-06-11)
+
+
+### Bug Fixes
+
+* base catchup on inscriptions db, vs blocks db ([a76a037](https://github.com/hirosystems/ordhook/commit/a76a037cf8965863e5bb2401637a2327f79dcb5f))
+* consider meta protocols when switching to stream ([#311](https://github.com/hirosystems/ordhook/issues/311)) ([26d8ed9](https://github.com/hirosystems/ordhook/commit/26d8ed9f5c3121f9caa7ca89436d980088e27bd8))
+* set is_streaming_blocks to false when scanning ([#309](https://github.com/hirosystems/ordhook/issues/309)) ([b31f6bd](https://github.com/hirosystems/ordhook/commit/b31f6bdea79a8a553b31f1492da80ffd8c35a6e5))
+
 ## [2.2.0](https://github.com/hirosystems/ordhook/compare/v2.1.0...v2.2.0) (2024-05-24)
 
 

--- a/components/ordhook-core/src/service/mod.rs
+++ b/components/ordhook-core/src/service/mod.rs
@@ -531,20 +531,6 @@ impl Service {
                 run_compaction(&blocks_db_rw, tip);
             }
         }
-        // Ensure that all the databases are correctly aligned
-        // Get height from inscription table
-        // -> There could be no inscription at this height.
-
-        // Get height from rocksdb
-
-        // Get height from inscription table
-
-        // Get height from locations table
-
-        // Get height from brc20 table
-
-        // Get height from metadata table
-
         self.update_state(block_post_processor).await
     }
 

--- a/components/ordhook-core/src/service/observers.rs
+++ b/components/ordhook-core/src/service/observers.rs
@@ -273,9 +273,7 @@ pub fn create_and_consolidate_chainhook_config_with_predicates(
                 expire_after_occurrence: None,
                 predicate: chainhook_sdk::chainhooks::types::BitcoinPredicateType::OrdinalsProtocol(
                     chainhook_sdk::chainhooks::types::OrdinalOperations::InscriptionFeed(
-                        InscriptionFeedData {
-                            meta_protocols,
-                        },
+                        InscriptionFeedData { meta_protocols },
                     ),
                 ),
                 action: chainhook_sdk::chainhooks::types::HookAction::Noop,


### PR DESCRIPTION
With the latest brc20 refactoring, we started experiencing some issues during re-org.
In this PR, we're revisiting the way the method `delete_data_in_ordhook_db` is being used by making sure that we're re-using existing readwrite connections handles if we already have some.  