### PR TITLE
fix: also check config when looking for brc20 db connection

### DIFF
--- a/components/ordhook-core/src/core/mod.rs
+++ b/components/ordhook-core/src/core/mod.rs
@@ -13,6 +13,7 @@ use chainhook_sdk::utils::Context;
 use crate::{
     config::{Config, LogConfig, MetaProtocolsConfig, ResourcesConfig},
     db::{find_pinned_block_bytes_at_block_height, open_ordhook_db_conn_rocks_db_loop},
+    initialize_databases,
     utils::bitcoind::bitcoind_get_block_height,
 };
 
@@ -152,7 +153,7 @@ pub fn should_sync_ordhook_db(
     let mut start_block = find_last_block_inserted(&blocks_db) as u64;
 
     if start_block == 0 {
-        let _ = initialize_ordhook_db(&config.expected_cache_path(), &ctx);
+        let _ = initialize_databases(config, ctx);
     }
 
     let inscriptions_db_conn = open_readonly_ordhook_db_conn(&config.expected_cache_path(), &ctx)?;

--- a/components/ordhook-core/src/lib.rs
+++ b/components/ordhook-core/src/lib.rs
@@ -36,7 +36,9 @@ pub struct DbConnections {
     pub brc20: Option<Connection>,
 }
 
-pub fn initialize_db(config: &Config, ctx: &Context) -> DbConnections {
+/// Initializes all SQLite databases required for Ordhook operation, depending if they are requested by the current `Config`.
+/// Returns a struct with all the open connections.
+pub fn initialize_databases(config: &Config, ctx: &Context) -> DbConnections {
     DbConnections {
         ordhook: initialize_ordhook_db(&config.expected_cache_path(), ctx),
         brc20: match config.meta_protocols.brc20 {


### PR DESCRIPTION
If an ordhook config toml did not include `brc20 = true`, a BRC-20 DB connection was still attempted

Fixes #324 
Fixes #326 