### PR TITLE
feat!: keep original deployed ticker for brc20 tokens

### DIFF
--- a/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
@@ -167,6 +167,7 @@ impl Brc20MemoryCache {
             inscription_number: reveal.inscription_number.jubilee as u64,
             block_height: block_identifier.index,
             tick: data.tick.clone(),
+            display_tick: data.display_tick.clone(),
             max: data.max,
             lim: data.lim,
             dec: data.dec,
@@ -365,6 +366,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -480,6 +482,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,

--- a/components/ordhook-core/src/core/meta_protocols/brc20/parser.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/parser.rs
@@ -6,6 +6,7 @@ use crate::ord::media::{Language, Media};
 #[derive(PartialEq, Debug, Clone)]
 pub struct ParsedBrc20TokenDeployData {
     pub tick: String,
+    pub display_tick: String,
     pub max: f64,
     pub lim: f64,
     pub dec: u64,
@@ -119,6 +120,7 @@ pub fn parse_brc20_operation(
             }
             let mut deploy = ParsedBrc20TokenDeployData {
                 tick: json.tick.to_lowercase(),
+                display_tick: json.tick.clone(),
                 max: 0.0,
                 lim: 0.0,
                 dec: 18,
@@ -263,6 +265,7 @@ mod test {
         InscriptionBuilder::new().build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 6,
@@ -277,6 +280,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "PEPE", "max": "21000000", "lim": "1000", "dec": "6"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "PEPE".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 6,
@@ -287,6 +291,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "pepe", "max": "21000000", "lim": "1000"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -297,6 +302,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "pepe", "max": "21000000"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 21000000.0,
             dec: 18,
@@ -307,6 +313,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "pepe", "max": "21000000", "dec": "7"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 21000000.0,
             dec: 7,
@@ -317,6 +324,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "😉", "max": "21000000", "lim": "1000", "dec": "6"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "😉".to_string(),
+            display_tick: "😉".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 6,
@@ -327,6 +335,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "a  b", "max": "21000000", "lim": "1000", "dec": "6"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "a  b".to_string(),
+            display_tick: "a  b".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 6,
@@ -337,6 +346,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "$pepe", "max": "21000000", "lim": "1000", "dec": "6", "self_mint": "true"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "$pepe".to_string(),
+            display_tick: "$pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 6,
@@ -347,6 +357,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "$pepe", "max": "0", "lim": "1000", "dec": "6", "self_mint": "true"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "$pepe".to_string(),
+            display_tick: "$pepe".to_string(),
             max: u64::MAX as f64,
             lim: 1000.0,
             dec: 6,
@@ -361,6 +372,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "pepe", "max": "21000000", "lim": "1000", "dec": "6", "foo": 99}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 6,
@@ -459,6 +471,7 @@ mod test {
         InscriptionBuilder::new().body(r#"{"p":"brc-20", "op": "deploy", "tick": "pepe", "max": "21000000", "lim": "1000", "dec": "0"}"#).build()
         => Ok(Some(ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 0,

--- a/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
@@ -12,6 +12,7 @@ use super::parser::{amt_has_valid_decimals, ParsedBrc20Operation};
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct VerifiedBrc20TokenDeployData {
     pub tick: String,
+    pub display_tick: String,
     pub max: f64,
     pub lim: f64,
     pub dec: u64,
@@ -75,6 +76,7 @@ pub fn verify_brc20_operation(
             return Ok(VerifiedBrc20Operation::TokenDeploy(
                 VerifiedBrc20TokenDeployData {
                     tick: data.tick.clone(),
+                    display_tick: data.display_tick.clone(),
                     max: data.max,
                     lim: data.lim,
                     dec: data.dec,
@@ -234,6 +236,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -245,6 +248,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "$pepe".to_string(),
+            display_tick: "$pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -257,6 +261,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "$pepe".to_string(),
+            display_tick: "$pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -265,6 +270,7 @@ mod test {
         (Brc20RevealBuilder::new().build(), 840000)
         => Ok(VerifiedBrc20Operation::TokenDeploy(VerifiedBrc20TokenDeployData {
             tick: "$pepe".to_string(),
+            display_tick: "$pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -276,6 +282,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -287,6 +294,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -298,6 +306,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -307,6 +316,7 @@ mod test {
         => Ok(
             VerifiedBrc20Operation::TokenDeploy(VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -358,6 +368,7 @@ mod test {
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
             tick: "pepe".to_string(),
+            display_tick: "pepe".to_string(),
             max: 21000000.0,
             lim: 1000.0,
             dec: 18,
@@ -429,6 +440,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -501,6 +513,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "$pepe".to_string(),
+                display_tick: "$pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -548,6 +561,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -610,6 +624,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -733,6 +748,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -851,6 +867,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,
@@ -925,6 +942,7 @@ mod test {
         cache.insert_token_deploy(
             &VerifiedBrc20TokenDeployData {
                 tick: "pepe".to_string(),
+                display_tick: "pepe".to_string(),
                 max: 21000000.0,
                 lim: 1000.0,
                 dec: 18,

--- a/components/ordhook-core/src/core/mod.rs
+++ b/components/ordhook-core/src/core/mod.rs
@@ -18,8 +18,7 @@ use crate::{
 };
 
 use crate::db::{
-    find_last_block_inserted, find_latest_inscription_block_height, initialize_ordhook_db,
-    open_readonly_ordhook_db_conn,
+    find_last_block_inserted, find_latest_inscription_block_height, open_readonly_ordhook_db_conn,
 };
 
 use crate::db::TransactionBytesCursor;

--- a/components/ordhook-core/src/scan/bitcoin.rs
+++ b/components/ordhook-core/src/scan/bitcoin.rs
@@ -1,11 +1,10 @@
 use crate::config::Config;
-use crate::core::meta_protocols::brc20::db::open_readonly_brc20_db_conn;
 use crate::core::protocol::inscription_parsing::{
     get_inscriptions_revealed_in_block, get_inscriptions_transferred_in_block,
     parse_inscriptions_and_standardize_block,
 };
 use crate::core::protocol::inscription_sequencing::consolidate_block_with_pre_computed_ordinals_data;
-use crate::db::{get_any_entry_in_ordinal_activities, open_readonly_ordhook_db_conn};
+use crate::db::get_any_entry_in_ordinal_activities;
 use crate::download::download_ordinals_dataset_if_required;
 use crate::initialize_databases;
 use crate::service::observers::{


### PR DESCRIPTION
Conserves original case of deployed ticker for BRC-20 tokens and uses it for predicate payloads.

Fixes #348 