### PR TITLE
feat: support a separate storage directory for observers.sqlite

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 ordhook-install = "install --path components/ordhook-cli --locked --force"
+
+[env]
+RUST_TEST_THREADS = "1"

--- a/components/ordhook-cli/src/cli/mod.rs
+++ b/components/ordhook-cli/src/cli/mod.rs
@@ -631,7 +631,10 @@ async fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
                                 if row.operation == "transfer_receive" {
                                     continue;
                                 }
-                                println!("BRC-20 {} {} {}", row.operation, row.tick, row.avail_balance);
+                                println!(
+                                    "BRC-20 {} {} {}",
+                                    row.operation, row.tick, row.avail_balance
+                                );
                             }
                         }
                         None => todo!(),

--- a/components/ordhook-cli/src/cli/mod.rs
+++ b/components/ordhook-cli/src/cli/mod.rs
@@ -579,7 +579,7 @@ async fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
                     false,
                 )?;
 
-                let _ = initialize_observers_db(&config.expected_cache_path(), ctx);
+                let _ = initialize_observers_db(&config, ctx);
 
                 scan_bitcoin_chainstate_via_rpc_using_predicate(
                     &predicate_spec,

--- a/components/ordhook-cli/src/config/file.rs
+++ b/components/ordhook-cli/src/config/file.rs
@@ -65,6 +65,7 @@ impl ConfigFile {
         let config = Config {
             storage: StorageConfig {
                 working_dir: config_file.storage.working_dir.unwrap_or("ordhook".into()),
+                observers_working_dir: config_file.storage.observers_working_dir.unwrap_or("observers".into()),
             },
             http_api: match config_file.http_api {
                 None => PredicatesApi::Off,
@@ -176,6 +177,7 @@ pub struct LogConfigFile {
 #[derive(Deserialize, Debug, Clone)]
 pub struct StorageConfigFile {
     pub working_dir: Option<String>,
+    pub observers_working_dir: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/components/ordhook-cli/src/config/file.rs
+++ b/components/ordhook-cli/src/config/file.rs
@@ -65,7 +65,10 @@ impl ConfigFile {
         let config = Config {
             storage: StorageConfig {
                 working_dir: config_file.storage.working_dir.unwrap_or("ordhook".into()),
-                observers_working_dir: config_file.storage.observers_working_dir.unwrap_or("observers".into()),
+                observers_working_dir: config_file
+                    .storage
+                    .observers_working_dir
+                    .unwrap_or("observers".into()),
             },
             http_api: match config_file.http_api {
                 None => PredicatesApi::Off,

--- a/components/ordhook-core/src/config/mod.rs
+++ b/components/ordhook-core/src/config/mod.rs
@@ -44,6 +44,7 @@ pub struct LogConfig {
 #[derive(Clone, Debug)]
 pub struct StorageConfig {
     pub working_dir: String,
+    pub observers_working_dir: String,
 }
 
 #[derive(Clone, Debug)]
@@ -161,10 +162,17 @@ impl Config {
         destination_path
     }
 
+    pub fn expected_observers_cache_path(&self) -> PathBuf {
+        let mut destination_path = PathBuf::new();
+        destination_path.push(&self.storage.observers_working_dir);
+        destination_path
+    }
+
     pub fn devnet_default() -> Config {
         Config {
             storage: StorageConfig {
                 working_dir: default_cache_path(),
+                observers_working_dir: default_observers_cache_path(),
             },
             http_api: PredicatesApi::Off,
             snapshot: SnapshotConfig::Build,
@@ -199,6 +207,7 @@ impl Config {
         Config {
             storage: StorageConfig {
                 working_dir: default_cache_path(),
+                observers_working_dir: default_observers_cache_path(),
             },
             http_api: PredicatesApi::Off,
             snapshot: SnapshotConfig::Build,
@@ -233,6 +242,7 @@ impl Config {
         Config {
             storage: StorageConfig {
                 working_dir: default_cache_path(),
+                observers_working_dir: default_observers_cache_path(),
             },
             http_api: PredicatesApi::Off,
             snapshot: SnapshotConfig::Download(SnapshotConfigDownloadUrls {
@@ -270,5 +280,11 @@ impl Config {
 pub fn default_cache_path() -> String {
     let mut cache_path = std::env::current_dir().expect("unable to get current dir");
     cache_path.push("ordhook");
+    format!("{}", cache_path.display())
+}
+
+pub fn default_observers_cache_path() -> String {
+    let mut cache_path = std::env::current_dir().expect("unable to get current dir");
+    cache_path.push("observers");
     format!("{}", cache_path.display())
 }

--- a/components/ordhook-core/src/core/meta_protocols/brc20/db.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/db.rs
@@ -9,9 +9,8 @@ use crate::{
 };
 use chainhook_sdk::{
     types::{
-        BitcoinBlockData, BitcoinTransactionData, BlockIdentifier, Brc20BalanceData,
-        Brc20Operation, Brc20TokenDeployData, Brc20TransferData, OrdinalInscriptionRevealData,
-        OrdinalOperation,
+        BitcoinBlockData, BitcoinTransactionData, Brc20BalanceData, Brc20Operation,
+        Brc20TokenDeployData, Brc20TransferData, OrdinalInscriptionRevealData, OrdinalOperation,
     },
     utils::Context,
 };

--- a/components/ordhook-core/src/download/mod.rs
+++ b/components/ordhook-core/src/download/mod.rs
@@ -190,7 +190,9 @@ async fn validate_or_download_archive_file(
 
     if should_download {
         try_info!(ctx, "Downloading {remote_archive_url}");
-        match download_and_decompress_archive_file(remote_archive_url, file_name, &config, &ctx).await {
+        match download_and_decompress_archive_file(remote_archive_url, file_name, &config, &ctx)
+            .await
+        {
             Ok(_) => {}
             Err(e) => {
                 try_error!(ctx, "{e}");

--- a/components/ordhook-core/src/scan/bitcoin.rs
+++ b/components/ordhook-core/src/scan/bitcoin.rs
@@ -158,7 +158,7 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
         }
         {
             let observers_db_conn =
-                open_readwrite_observers_db_conn_or_panic(&config.expected_cache_path(), &ctx);
+                open_readwrite_observers_db_conn_or_panic(&config, &ctx);
             update_observer_progress(
                 &predicate_spec.uuid,
                 current_block_height,

--- a/components/ordhook-core/src/scan/bitcoin.rs
+++ b/components/ordhook-core/src/scan/bitcoin.rs
@@ -157,8 +157,7 @@ pub async fn scan_bitcoin_chainstate_via_rpc_using_predicate(
             Err(e) => return Err(format!("Scan aborted: {e}")),
         }
         {
-            let observers_db_conn =
-                open_readwrite_observers_db_conn_or_panic(&config, &ctx);
+            let observers_db_conn = open_readwrite_observers_db_conn_or_panic(&config, &ctx);
             update_observer_progress(
                 &predicate_spec.uuid,
                 current_block_height,

--- a/components/ordhook-core/src/service/http_api.rs
+++ b/components/ordhook-core/src/service/http_api.rs
@@ -705,18 +705,10 @@ mod test {
 
         let client = Client::new();
         let _ = register_predicate(&client, &observer_event_tx).await;
-        let response = client
-            .delete("http://localhost:20456/v1/observers/00000001-0001-0001-0001-000000000001")
-            .send()
-            .await
-            .unwrap();
-        assert!(response.status().is_success());
+        let response = register_predicate(&client, &observer_event_tx).await;
+        assert_eq!(response.status(), reqwest::StatusCode::CONFLICT);
         let json: Value = response.json().await.unwrap();
-        assert_eq!(json["status"], 200);
-        assert_eq!(
-            json["result"]["uuid"],
-            "00000001-0001-0001-0001-000000000001"
-        );
+        assert_eq!(json["status"], 409);
 
         shutdown_server(observer_event_tx, shutdown);
     }

--- a/components/ordhook-core/src/service/mod.rs
+++ b/components/ordhook-core/src/service/mod.rs
@@ -270,19 +270,20 @@ impl Service {
             .expect("unable to spawn thread");
 
         if let PredicatesApi::On(ref api_config) = self.config.http_api {
-            info!(
-                self.ctx.expect_logger(),
-                "Listening on port {} for chainhook predicate registrations", api_config.http_port
+            try_info!(
+                self.ctx,
+                "Listening on port {} for chainhook predicate registrations",
+                api_config.http_port
             );
             let ctx = self.ctx.clone();
             let api_config = api_config.clone();
             let moved_observer_command_tx = observer_command_tx.clone();
-            let db_dir_path = self.config.expected_cache_path();
+            let observers_db_dir_path = self.config.expected_observers_cache_path();
             // Test and initialize a database connection
             let _ = hiro_system_kit::thread_named("HTTP Predicate API").spawn(move || {
                 let future = start_predicate_api_server(
                     api_config.http_port,
-                    db_dir_path,
+                    observers_db_dir_path,
                     moved_observer_command_tx,
                     ctx,
                 );
@@ -294,8 +295,8 @@ impl Service {
             let event = match observer_event_rx.recv() {
                 Ok(cmd) => cmd,
                 Err(e) => {
-                    error!(
-                        self.ctx.expect_logger(),
+                    try_error!(
+                        self.ctx,
                         "Error: broken channel {}",
                         e.to_string()
                     );

--- a/components/ordhook-core/src/service/mod.rs
+++ b/components/ordhook-core/src/service/mod.rs
@@ -29,12 +29,7 @@ use crate::db::{
 };
 use crate::db::{find_missing_blocks, run_compaction, update_sequence_metadata_with_block};
 use crate::scan::bitcoin::process_block_with_predicates;
-use crate::service::http_api::start_predicate_api_server;
-use crate::service::observers::{
-    create_and_consolidate_chainhook_config_with_predicates, insert_entry_in_observers,
-    open_readwrite_observers_db_conn, remove_entry_from_observers, update_observer_progress,
-    update_observer_streaming_enabled, ObserverReport,
-};
+use crate::service::observers::create_and_consolidate_chainhook_config_with_predicates;
 use crate::service::runloops::start_bitcoin_scan_runloop;
 use crate::{try_debug, try_error, try_info};
 use chainhook_sdk::chainhooks::bitcoin::BitcoinChainhookOccurrencePayload;
@@ -55,6 +50,7 @@ use crossbeam_channel::unbounded;
 use crossbeam_channel::{select, Sender};
 use dashmap::DashMap;
 use fxhash::FxHasher;
+use http_api::start_observers_http_server;
 use rusqlite::Transaction;
 
 use std::collections::{BTreeMap, HashMap};
@@ -250,7 +246,7 @@ impl Service {
         &self,
         observer_command_tx: &std::sync::mpsc::Sender<ObserverCommand>,
         observer_event_rx: crossbeam_channel::Receiver<ObserverEvent>,
-        predicate_activity_relayer: Option<
+        _predicate_activity_relayer: Option<
             crossbeam_channel::Sender<BitcoinChainhookOccurrencePayload>,
         >,
     ) -> Result<(), String> {
@@ -269,139 +265,19 @@ impl Service {
             })
             .expect("unable to spawn thread");
 
-        if let PredicatesApi::On(ref api_config) = self.config.http_api {
-            try_info!(
-                self.ctx,
-                "Listening on port {} for chainhook predicate registrations",
-                api_config.http_port
-            );
+        if let PredicatesApi::On(_) = self.config.http_api {
             let moved_config = self.config.clone();
             let moved_ctx = self.ctx.clone();
-            let moved_observer_command_tx = observer_command_tx.clone();
-            let _ = hiro_system_kit::thread_named("HTTP Predicate API").spawn(move || {
-                let future = start_predicate_api_server(
-                    moved_observer_command_tx,
+            let moved_observer_commands_tx = observer_command_tx.clone();
+            let _ = hiro_system_kit::thread_named("HTTP Observers API").spawn(move || {
+                let _ = hiro_system_kit::nestable_block_on(start_observers_http_server(
                     &moved_config,
+                    &moved_observer_commands_tx,
+                    observer_event_rx,
+                    bitcoin_scan_op_tx,
                     &moved_ctx,
-                );
-                let _ = hiro_system_kit::nestable_block_on(future);
+                ));
             });
-        }
-
-        loop {
-            let event = match observer_event_rx.recv() {
-                Ok(cmd) => cmd,
-                Err(e) => {
-                    try_error!(
-                        self.ctx,
-                        "Error: broken channel {}",
-                        e.to_string()
-                    );
-                    break;
-                }
-            };
-            match event {
-                ObserverEvent::PredicateRegistered(spec) => {
-                    // ?? That seems weird?
-                    // If start block specified, use it.
-                    // If no start block specified, depending on the nature the hook, we'd like to retrieve:
-                    // - contract-id
-                    let observers_db_conn = match open_readwrite_observers_db_conn(
-                        &self.config,
-                        &self.ctx,
-                    ) {
-                        Ok(con) => con,
-                        Err(e) => {
-                            error!(
-                                self.ctx.expect_logger(),
-                                "unable to register predicate: {}",
-                                e.to_string()
-                            );
-                            continue;
-                        }
-                    };
-                    let report = ObserverReport::default();
-                    insert_entry_in_observers(&spec, &report, &observers_db_conn, &self.ctx);
-                    match spec {
-                        ChainhookSpecification::Stacks(_predicate_spec) => {}
-                        ChainhookSpecification::Bitcoin(predicate_spec) => {
-                            let _ = bitcoin_scan_op_tx.send(predicate_spec);
-                        }
-                    }
-                }
-                ObserverEvent::PredicateEnabled(spec) => {
-                    let observers_db_conn = match open_readwrite_observers_db_conn(
-                        &self.config,
-                        &self.ctx,
-                    ) {
-                        Ok(con) => con,
-                        Err(e) => {
-                            error!(
-                                self.ctx.expect_logger(),
-                                "unable to enable observer: {}",
-                                e.to_string()
-                            );
-                            continue;
-                        }
-                    };
-                    update_observer_streaming_enabled(
-                        &spec.uuid(),
-                        true,
-                        &observers_db_conn,
-                        &self.ctx,
-                    );
-                }
-                ObserverEvent::PredicateDeregistered(uuid) => {
-                    let observers_db_conn = match open_readwrite_observers_db_conn(
-                        &self.config,
-                        &self.ctx,
-                    ) {
-                        Ok(con) => con,
-                        Err(e) => {
-                            error!(
-                                self.ctx.expect_logger(),
-                                "unable to deregister observer: {}",
-                                e.to_string()
-                            );
-                            continue;
-                        }
-                    };
-                    remove_entry_from_observers(&uuid, &observers_db_conn, &self.ctx);
-                }
-                ObserverEvent::BitcoinPredicateTriggered(data) => {
-                    if let Some(ref tip) = data.apply.last() {
-                        let observers_db_conn = match open_readwrite_observers_db_conn(
-                            &self.config,
-                            &self.ctx,
-                        ) {
-                            Ok(con) => con,
-                            Err(e) => {
-                                error!(
-                                    self.ctx.expect_logger(),
-                                    "unable to update observer: {}",
-                                    e.to_string()
-                                );
-                                continue;
-                            }
-                        };
-                        let last_block_height_update = tip.block.block_identifier.index;
-                        update_observer_progress(
-                            &data.chainhook.uuid,
-                            last_block_height_update,
-                            &observers_db_conn,
-                            &self.ctx,
-                        )
-                    }
-                    if let Some(ref tx) = predicate_activity_relayer {
-                        let _ = tx.send(data);
-                    }
-                }
-                ObserverEvent::Terminate => {
-                    info!(self.ctx.expect_logger(), "Terminating runloop");
-                    break;
-                }
-                _ => {}
-            }
         }
 
         Ok(())

--- a/components/ordhook-core/src/service/observers.rs
+++ b/components/ordhook-core/src/service/observers.rs
@@ -129,7 +129,7 @@ pub fn initialize_observers_db(config: &Config, ctx: &Context) -> Connection {
 #[cfg(test)]
 pub fn delete_observers_db(config: &Config) {
     let path = get_default_observers_db_file_path(config);
-    std::fs::remove_file(path).expect("unable to delete observers db");
+    let _ = std::fs::remove_file(path);
 }
 
 #[derive(Default, Clone, Serialize, Deserialize)]

--- a/components/ordhook-core/src/service/observers.rs
+++ b/components/ordhook-core/src/service/observers.rs
@@ -73,32 +73,32 @@ pub fn insert_entry_in_observers(
     }
 }
 
-pub fn get_default_observers_db_file_path(base_dir: &PathBuf) -> PathBuf {
-    let mut destination_path = base_dir.clone();
+fn get_default_observers_db_file_path(config: &Config) -> PathBuf {
+    let mut destination_path = config.expected_observers_cache_path().clone();
     destination_path.push("observers.sqlite");
     destination_path
 }
 
 pub fn open_readonly_observers_db_conn(
-    base_dir: &PathBuf,
+    config: &Config,
     ctx: &Context,
 ) -> Result<Connection, String> {
-    let db_path = get_default_observers_db_file_path(&base_dir);
+    let db_path = get_default_observers_db_file_path(config);
     let conn = open_existing_readonly_db(&db_path, ctx);
     Ok(conn)
 }
 
 pub fn open_readwrite_observers_db_conn(
-    base_dir: &PathBuf,
+    config: &Config,
     ctx: &Context,
 ) -> Result<Connection, String> {
-    let db_path = get_default_observers_db_file_path(&base_dir);
+    let db_path = get_default_observers_db_file_path(config);
     let conn = create_or_open_readwrite_db(Some(&db_path), ctx);
     Ok(conn)
 }
 
-pub fn open_readwrite_observers_db_conn_or_panic(base_dir: &PathBuf, ctx: &Context) -> Connection {
-    let conn = match open_readwrite_observers_db_conn(base_dir, ctx) {
+pub fn open_readwrite_observers_db_conn_or_panic(config: &Config, ctx: &Context) -> Connection {
+    let conn = match open_readwrite_observers_db_conn(config, ctx) {
         Ok(con) => con,
         Err(message) => {
             error!(ctx.expect_logger(), "Storage: {}", message.to_string());
@@ -108,8 +108,8 @@ pub fn open_readwrite_observers_db_conn_or_panic(base_dir: &PathBuf, ctx: &Conte
     conn
 }
 
-pub fn initialize_observers_db(base_dir: &PathBuf, ctx: &Context) -> Connection {
-    let db_path = get_default_observers_db_file_path(&base_dir);
+pub fn initialize_observers_db(config: &Config, ctx: &Context) -> Connection {
+    let db_path = get_default_observers_db_file_path(config);
     let conn = create_or_open_readwrite_db(Some(&db_path), ctx);
     // TODO: introduce initial output
     if let Err(e) = conn.execute(
@@ -263,7 +263,7 @@ pub fn create_and_consolidate_chainhook_config_with_predicates(
         ));
     }
 
-    let observers_db_conn = initialize_observers_db(&config.expected_cache_path(), ctx);
+    let observers_db_conn = initialize_observers_db(config, ctx);
 
     let mut observers_to_catchup = vec![];
     let mut observers_to_clean_up = vec![];

--- a/components/ordhook-core/src/service/observers.rs
+++ b/components/ordhook-core/src/service/observers.rs
@@ -126,6 +126,12 @@ pub fn initialize_observers_db(config: &Config, ctx: &Context) -> Connection {
     conn
 }
 
+#[cfg(test)]
+pub fn delete_observers_db(config: &Config) {
+    let path = get_default_observers_db_file_path(config);
+    std::fs::remove_file(path).expect("unable to delete observers db");
+}
+
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct ObserverReport {
     pub streaming_enabled: bool,

--- a/components/ordhook-core/src/service/runloops.rs
+++ b/components/ordhook-core/src/service/runloops.rs
@@ -28,7 +28,6 @@ pub fn start_bitcoin_scan_runloop(
         let moved_ctx = ctx.clone();
         let moved_config = config.clone();
         let observer_command_tx = observer_command_tx.clone();
-        let db_base_dir = config.expected_cache_path();
         bitcoin_scan_pool.execute(move || {
             let op = scan_bitcoin_chainstate_via_rpc_using_predicate(
                 &predicate_spec,
@@ -47,7 +46,7 @@ pub fn start_bitcoin_scan_runloop(
 
                     // Update predicate
                     let mut observers_db_conn =
-                        open_readwrite_observers_db_conn_or_panic(&db_base_dir, &moved_ctx);
+                        open_readwrite_observers_db_conn_or_panic(&moved_config, &moved_ctx);
                     update_observer_streaming_enabled(
                         &predicate_spec.uuid,
                         false,

--- a/components/ordhook-core/src/service/runloops.rs
+++ b/components/ordhook-core/src/service/runloops.rs
@@ -10,8 +10,8 @@ use threadpool::ThreadPool;
 use crate::{
     config::Config,
     scan::bitcoin::scan_bitcoin_chainstate_via_rpc_using_predicate,
-    service::{
-        observers::open_readwrite_observers_db_conn_or_panic, update_observer_streaming_enabled,
+    service::observers::{
+        open_readwrite_observers_db_conn_or_panic, update_observer_streaming_enabled,
     },
     try_error,
 };


### PR DESCRIPTION
Allows configuring a separate storage directory for `observers.sqlite` so state data can live separately and observer configuration is not reflected in data snapshots that might be moved to different environments.

In the config .toml file, this is now controlled by the `observers_working_dir` value:
```toml
[storage]
working_dir = "tmp"
observers_working_dir = "observers"
```
****
Additional work:
* Consolidates observer API server creation methods in a single file
* Adds unit tests for all API endpoints
* Adds validations when manipulating predicates

Fixes #274 