### PR TITLE
fix: only create brc-20 db connection and cache if required

### DIFF
--- a/components/ordhook-cli/src/cli/mod.rs
+++ b/components/ordhook-cli/src/cli/mod.rs
@@ -17,7 +17,7 @@ use ordhook::chainhook_sdk::utils::BlockHeights;
 use ordhook::chainhook_sdk::utils::Context;
 use ordhook::config::Config;
 use ordhook::core::meta_protocols::brc20::db::{
-    get_brc20_operations_on_block, open_readwrite_brc20_db_conn,
+    brc20_new_rw_db_conn, get_brc20_operations_on_block, open_readwrite_brc20_db_conn
 };
 use ordhook::core::new_traversals_lazy_cache;
 use ordhook::core::pipeline::download_and_pipeline_blocks;
@@ -954,14 +954,7 @@ async fn handle_command(opts: Opts, ctx: &Context) -> Result<(), String> {
                 config.resources.memory_available,
                 &ctx,
             )?;
-            let brc_20_db_conn_rw = if config.meta_protocols.brc20 {
-                Some(open_readwrite_brc20_db_conn(
-                    &config.expected_cache_path(),
-                    ctx,
-                )?)
-            } else {
-                None
-            };
+            let brc_20_db_conn_rw = brc20_new_rw_db_conn(&config, ctx);
 
             delete_data_in_ordhook_db(
                 cmd.start_block,

--- a/components/ordhook-cli/src/cli/mod.rs
+++ b/components/ordhook-cli/src/cli/mod.rs
@@ -17,7 +17,7 @@ use ordhook::chainhook_sdk::utils::BlockHeights;
 use ordhook::chainhook_sdk::utils::Context;
 use ordhook::config::Config;
 use ordhook::core::meta_protocols::brc20::db::{
-    brc20_new_rw_db_conn, get_brc20_operations_on_block, open_readwrite_brc20_db_conn
+    brc20_new_rw_db_conn, get_brc20_operations_on_block,
 };
 use ordhook::core::new_traversals_lazy_cache;
 use ordhook::core::pipeline::download_and_pipeline_blocks;
@@ -42,10 +42,10 @@ use reqwest::Client as HttpClient;
 use std::collections::HashSet;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
-use std::{process, u64};
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
+use std::{process, u64};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
@@ -7,7 +7,7 @@ use chainhook_sdk::{
 use lru::LruCache;
 use rusqlite::{Connection, Transaction};
 
-use crate::core::meta_protocols::brc20::db::get_unsent_token_transfer;
+use crate::{config::Config, core::meta_protocols::brc20::db::get_unsent_token_transfer};
 
 use super::{
     db::{
@@ -16,6 +16,10 @@ use super::{
     },
     verifier::{VerifiedBrc20BalanceData, VerifiedBrc20TokenDeployData, VerifiedBrc20TransferData},
 };
+
+pub fn brc20_new_cache(config: &Config) -> Brc20MemoryCache {
+    Brc20MemoryCache::new(config.resources.brc20_lru_cache_size)
+}
 
 /// Keeps BRC20 DB rows before they're inserted into SQLite. Use `flush` to insert.
 pub struct Brc20DbCache {

--- a/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
@@ -17,8 +17,13 @@ use super::{
     verifier::{VerifiedBrc20BalanceData, VerifiedBrc20TokenDeployData, VerifiedBrc20TransferData},
 };
 
-pub fn brc20_new_cache(config: &Config) -> Brc20MemoryCache {
-    Brc20MemoryCache::new(config.resources.brc20_lru_cache_size)
+/// If the given `config` has BRC-20 enabled, returns a BRC-20 memory cache.
+pub fn brc20_new_cache(config: &Config) -> Option<Brc20MemoryCache> {
+    if config.meta_protocols.brc20 {
+        Some(Brc20MemoryCache::new(config.resources.brc20_lru_cache_size))
+    } else {
+        None
+    }
 }
 
 /// Keeps BRC20 DB rows before they're inserted into SQLite. Use `flush` to insert.

--- a/components/ordhook-core/src/core/meta_protocols/brc20/db.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/db.rs
@@ -2,10 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use crate::{
     config::Config,
-    db::{
-        create_or_open_readwrite_db, open_existing_readonly_db, perform_query_one,
-        perform_query_set,
-    },
+    db::{create_or_open_readwrite_db, perform_query_one, perform_query_set},
     try_error, try_warn,
 };
 use chainhook_sdk::{
@@ -148,10 +145,7 @@ pub fn initialize_brc20_db(base_dir: Option<&PathBuf>, ctx: &Context) -> Connect
     conn
 }
 
-fn open_readwrite_brc20_db_conn(
-    base_dir: &PathBuf,
-    ctx: &Context,
-) -> Result<Connection, String> {
+fn open_readwrite_brc20_db_conn(base_dir: &PathBuf, ctx: &Context) -> Result<Connection, String> {
     let db_path = get_default_brc20_db_file_path(&base_dir);
     let conn = create_or_open_readwrite_db(Some(&db_path), ctx);
     Ok(conn)

--- a/components/ordhook-core/src/core/meta_protocols/brc20/db.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/db.rs
@@ -148,21 +148,12 @@ pub fn initialize_brc20_db(base_dir: Option<&PathBuf>, ctx: &Context) -> Connect
     conn
 }
 
-pub fn open_readwrite_brc20_db_conn(
+fn open_readwrite_brc20_db_conn(
     base_dir: &PathBuf,
     ctx: &Context,
 ) -> Result<Connection, String> {
     let db_path = get_default_brc20_db_file_path(&base_dir);
     let conn = create_or_open_readwrite_db(Some(&db_path), ctx);
-    Ok(conn)
-}
-
-pub fn open_readonly_brc20_db_conn(
-    base_dir: &PathBuf,
-    ctx: &Context,
-) -> Result<Connection, String> {
-    let db_path = get_default_brc20_db_file_path(&base_dir);
-    let conn = open_existing_readonly_db(&db_path, ctx);
     Ok(conn)
 }
 

--- a/components/ordhook-core/src/core/pipeline/processors/inscription_indexing.rs
+++ b/components/ordhook-core/src/core/pipeline/processors/inscription_indexing.rs
@@ -177,14 +177,13 @@ pub fn process_blocks(
     sequence_cursor: &mut SequenceCursor,
     cache_l2: &Arc<DashMap<(u32, [u8; 8]), TransactionBytesCursor, BuildHasherDefault<FxHasher>>>,
     inscriptions_db_conn_rw: &mut Connection,
-    brc20_cache: &mut Brc20MemoryCache,
+    brc20_cache: &mut Option<Brc20MemoryCache>,
     brc20_db_conn_rw: &mut Option<Connection>,
     ordhook_config: &OrdhookConfig,
     post_processor: &Option<Sender<BitcoinBlockData>>,
     ctx: &Context,
 ) -> Vec<BitcoinBlockData> {
     let mut cache_l1 = BTreeMap::new();
-
     let mut updated_blocks = vec![];
 
     for _cursor in 0..next_blocks.len() {
@@ -216,7 +215,7 @@ pub fn process_blocks(
             cache_l2,
             &inscriptions_db_tx,
             brc20_db_tx.as_ref(),
-            brc20_cache,
+            brc20_cache.as_mut(),
             ordhook_config,
             ctx,
         );
@@ -284,7 +283,7 @@ pub fn process_block(
     cache_l2: &Arc<DashMap<(u32, [u8; 8]), TransactionBytesCursor, BuildHasherDefault<FxHasher>>>,
     inscriptions_db_tx: &Transaction,
     brc20_db_tx: Option<&Transaction>,
-    brc20_cache: &mut Brc20MemoryCache,
+    brc20_cache: Option<&mut Brc20MemoryCache>,
     ordhook_config: &OrdhookConfig,
     ctx: &Context,
 ) -> Result<(), String> {
@@ -322,14 +321,15 @@ pub fn process_block(
     // Handle transfers
     let _ = augment_block_with_ordinals_transfer_data(block, inscriptions_db_tx, true, &inner_ctx);
 
-    if let Some(brc20_db_tx) = brc20_db_tx {
-        write_brc20_block_operations(
+    match (brc20_db_tx, brc20_cache) {
+        (Some(brc20_db_tx), Some(brc20_cache)) => write_brc20_block_operations(
             block,
             &mut brc20_operation_map,
             brc20_cache,
-            &brc20_db_tx,
+            brc20_db_tx,
             &ctx,
-        );
+        ),
+        _ => {}
     }
 
     Ok(())

--- a/components/ordhook-core/src/db/mod.rs
+++ b/components/ordhook-core/src/db/mod.rs
@@ -560,7 +560,7 @@ pub fn update_ordinals_db_with_block(
         let (tx, output_index, offset) =
             parse_satpoint_to_watch(&inscription_data.satpoint_post_inscription);
         let outpoint_to_watch = format_outpoint_to_watch(&tx, output_index);
-        let insertion_res = locations_to_insert.insert(
+        let _ = locations_to_insert.insert(
             (inscription_data.ordinal_number, outpoint_to_watch),
             OrdinalLocation {
                 offset,
@@ -568,21 +568,13 @@ pub fn update_ordinals_db_with_block(
                 tx_index: inscription_data.tx_index,
             },
         );
-        if let Some(prev_location) = insertion_res {
-            try_warn!(
-                ctx,
-                "Ignoring location insertion from inscriptions: {}, {:?}",
-                inscription_data.ordinal_number,
-                prev_location
-            );
-        }
     }
 
     for transfer_data in get_inscriptions_transferred_in_block(&block).iter() {
         let (tx, output_index, offset) =
             parse_satpoint_to_watch(&transfer_data.satpoint_post_transfer);
         let outpoint_to_watch = format_outpoint_to_watch(&tx, output_index);
-        let insertion_res = locations_to_insert.insert(
+        let _ = locations_to_insert.insert(
             (transfer_data.ordinal_number, outpoint_to_watch),
             OrdinalLocation {
                 offset,
@@ -590,14 +582,6 @@ pub fn update_ordinals_db_with_block(
                 tx_index: transfer_data.tx_index,
             },
         );
-        if let Some(prev_location) = insertion_res {
-            try_warn!(
-                ctx,
-                "Ignoring location insertion from transfers: {}, {:?}",
-                transfer_data.ordinal_number,
-                prev_location
-            );
-        }
     }
 
     for ((ordinal_number, outpoint_to_watch), location_data) in locations_to_insert {

--- a/components/ordhook-core/src/service/http_api.rs
+++ b/components/ordhook-core/src/service/http_api.rs
@@ -41,6 +41,8 @@ pub async fn start_observers_http_server(
     bitcoin_scan_op_tx: crossbeam_channel::Sender<BitcoinChainhookSpecification>,
     ctx: &Context,
 ) -> Result<Shutdown, String> {
+    try_info!(ctx, "Starting observers HTTP server");
+
     // Build and start HTTP server.
     let ignite = build_server(config, observer_commands_tx, ctx).await;
     let shutdown = ignite.shutdown();

--- a/components/ordhook-core/src/service/http_api.rs
+++ b/components/ordhook-core/src/service/http_api.rs
@@ -41,8 +41,6 @@ pub async fn start_observers_http_server(
     bitcoin_scan_op_tx: crossbeam_channel::Sender<BitcoinChainhookSpecification>,
     ctx: &Context,
 ) -> Result<Shutdown, String> {
-    try_info!(ctx, "Starting observers HTTP server");
-
     // Build and start HTTP server.
     let ignite = build_server(config, observer_commands_tx, ctx).await;
     let shutdown = ignite.shutdown();
@@ -56,10 +54,7 @@ pub async fn start_observers_http_server(
     let _ = hiro_system_kit::thread_named("observers_api-events").spawn(move || loop {
         let event = match observer_event_rx.recv() {
             Ok(cmd) => cmd,
-            Err(e) => {
-                try_error!(&moved_ctx, "Error: broken channel {}", e.to_string());
-                break;
-            }
+            Err(_) => break
         };
         match event {
             ObserverEvent::PredicateRegistered(spec) => {
@@ -138,10 +133,6 @@ pub async fn start_observers_http_server(
                     )
                 }
             }
-            ObserverEvent::Terminate => {
-                try_info!(&moved_ctx, "Terminating runloop");
-                break;
-            }
             _ => {}
         }
     });
@@ -157,6 +148,7 @@ async fn build_server(
     let PredicatesApi::On(ref api_config) = config.http_api else {
         unreachable!();
     };
+    try_info!(ctx, "Listening on port {} for chainhook predicate registrations", api_config.http_port);
     let moved_config = config.clone();
     let moved_ctx = ctx.clone();
     let moved_observer_commands_tx = observer_command_tx.clone();

--- a/components/ordhook-core/src/service/runloops.rs
+++ b/components/ordhook-core/src/service/runloops.rs
@@ -13,7 +13,7 @@ use crate::{
     service::observers::{
         open_readwrite_observers_db_conn_or_panic, update_observer_streaming_enabled,
     },
-    try_error,
+    try_error, try_info,
 };
 
 pub fn start_bitcoin_scan_runloop(
@@ -22,8 +22,8 @@ pub fn start_bitcoin_scan_runloop(
     observer_command_tx: Sender<ObserverCommand>,
     ctx: &Context,
 ) {
+    try_info!(ctx, "Starting bitcoin scan runloop");
     let bitcoin_scan_pool = ThreadPool::new(config.resources.expected_observers_count);
-
     while let Ok(predicate_spec) = bitcoin_scan_op_rx.recv() {
         let moved_ctx = ctx.clone();
         let moved_config = config.clone();


### PR DESCRIPTION
Consolidates the creation of BRC-20 DB and cache so it only happens when the `Ordhook.toml` config requires it.