### PR TITLE
feat: wait for bitcoind to be at chain tip before starting service

### DIFF
--- a/components/ordhook-core/src/utils/bitcoind.rs
+++ b/components/ordhook-core/src/utils/bitcoind.rs
@@ -57,6 +57,7 @@ pub fn bitcoind_wait_for_chain_tip(config: &Config, ctx: &Context) {
                     // Wait for 10 confirmations before declaring node is at chain tip, just in case it's still connecting to
                     // peers.
                     if confirmations == 10 {
+                        try_info!(ctx, "bitcoind: Chain tip reached");
                         return;
                     }
                     try_info!(ctx, "bitcoind: Verifying chain tip");

--- a/components/ordhook-core/src/utils/bitcoind.rs
+++ b/components/ordhook-core/src/utils/bitcoind.rs
@@ -61,6 +61,7 @@ pub fn bitcoind_wait_for_chain_tip(config: &Config, ctx: &Context) {
                     }
                     try_info!(ctx, "bitcoind: Verifying chain tip");
                 } else {
+                    confirmations = 0;
                     try_info!(ctx, "bitcoind: Node has not reached chain tip, trying again");
                 }
             }

--- a/components/ordhook-core/src/utils/bitcoind.rs
+++ b/components/ordhook-core/src/utils/bitcoind.rs
@@ -1,9 +1,11 @@
+use std::{thread::sleep, time::Duration};
+
 use chainhook_sdk::{
     bitcoincore_rpc::{Auth, Client, RpcApi},
     utils::Context,
 };
 
-use crate::{config::Config, try_error};
+use crate::{config::Config, try_error, try_info};
 
 fn bitcoind_get_client(config: &Config, ctx: &Context) -> Client {
     loop {
@@ -16,8 +18,8 @@ fn bitcoind_get_client(config: &Config, ctx: &Context) -> Client {
                 return con;
             }
             Err(e) => {
-                try_error!(ctx, "bitcoind unable to get client: {}", e.to_string());
-                std::thread::sleep(std::time::Duration::from_secs(1));
+                try_error!(ctx, "bitcoind: Unable to get client: {}", e.to_string());
+                sleep(Duration::from_secs(1));
             }
         }
     }
@@ -34,11 +36,42 @@ pub fn bitcoind_get_block_height(config: &Config, ctx: &Context) -> u64 {
             Err(e) => {
                 try_error!(
                     ctx,
-                    "bitcoind unable to get block height: {}",
+                    "bitcoind: Unable to get block height: {}",
                     e.to_string()
                 );
-                std::thread::sleep(std::time::Duration::from_secs(1));
+                sleep(Duration::from_secs(1));
             }
         };
+    }
+}
+
+/// Checks if bitcoind is still synchronizing blocks and waits until it's finished if that is the case.
+pub fn bitcoind_wait_for_chain_tip(config: &Config, ctx: &Context) {
+    let bitcoin_rpc = bitcoind_get_client(config, ctx);
+    let mut confirmations = 0;
+    loop {
+        match bitcoin_rpc.get_blockchain_info() {
+            Ok(result) => {
+                if result.initial_block_download == false && result.blocks == result.headers {
+                    confirmations += 1;
+                    // Wait for 10 confirmations before declaring node is at chain tip, just in case it's still connecting to
+                    // peers.
+                    if confirmations == 10 {
+                        return;
+                    }
+                    try_info!(ctx, "bitcoind: Verifying chain tip");
+                } else {
+                    try_info!(ctx, "bitcoind: Node has not reached chain tip, trying again");
+                }
+            }
+            Err(e) => {
+                try_error!(
+                    ctx,
+                    "bitcoind: Unable to check for chain tip: {}",
+                    e.to_string()
+                );
+            }
+        };
+        sleep(Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
Before starting either the indexing service or a DB index sync, check that bitcoind is at chain tip relative to its peers. This allows us to boot up ordhook at the same time as a Bitcoin node even if that node is behind the Bitcoin chain tip.

Fixes #289 