### PR TITLE
feat: add database migration cli commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.41",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/components/ordhook-core/src/core/meta_protocols/brc20/brc20_pg.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/brc20_pg.rs
@@ -562,7 +562,7 @@ mod test {
                 VerifiedBrc20BalanceData, VerifiedBrc20TokenDeployData, VerifiedBrc20TransferData,
             },
         },
-        db::{pg_test_clear_db, pg_test_connection, pg_test_connection_pool},
+        db::{pg_reset_db, pg_test_connection, pg_test_connection_pool},
     };
 
     async fn get_counts_by_operation<T: GenericClient>(client: &T) -> (i32, i32, i32, i32) {
@@ -1000,7 +1000,7 @@ mod test {
                 );
             }
         }
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         Ok(())
     }
 }

--- a/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
@@ -487,7 +487,7 @@ mod test {
                 VerifiedBrc20TokenDeployData,
             },
         },
-        db::{pg_test_clear_db, pg_test_connection, pg_test_connection_pool},
+        db::{pg_reset_db, pg_test_connection, pg_test_connection_pool},
     };
 
     use super::Brc20MemoryCache;
@@ -641,7 +641,7 @@ mod test {
                     )))
             );
         }
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         Ok(())
     }
 
@@ -743,7 +743,7 @@ mod test {
                 )
                 .await?)
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 }

--- a/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
@@ -279,7 +279,7 @@ mod test {
                 VerifiedBrc20BalanceData, VerifiedBrc20Operation, VerifiedBrc20TokenDeployData,
             },
         },
-        db::{pg_test_clear_db, pg_test_connection, pg_test_connection_pool},
+        db::{pg_reset_db, pg_test_connection, pg_test_connection_pool},
     };
 
     use super::{verify_brc20_operation, verify_brc20_transfer, VerifiedBrc20TransferData};
@@ -421,7 +421,7 @@ mod test {
             )
             .await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -534,7 +534,7 @@ mod test {
             )
             .await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -621,7 +621,7 @@ mod test {
             )
             .await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -698,7 +698,7 @@ mod test {
             )
             .await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -778,7 +778,7 @@ mod test {
             )
             .await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -941,7 +941,7 @@ mod test {
             )
             .await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -1067,7 +1067,7 @@ mod test {
             ).await?;
             verify_brc20_transfer(&transfer, &mut cache, &client, &ctx).await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 
@@ -1175,7 +1175,7 @@ mod test {
                 .await?;
             verify_brc20_transfer(&transfer, &mut cache, &client, &ctx).await
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         result
     }
 }

--- a/components/ordhook-core/src/core/protocol/sequence_cursor.rs
+++ b/components/ordhook-core/src/core/protocol/sequence_cursor.rs
@@ -151,7 +151,7 @@ mod test {
         core::test_builders::{TestBlockBuilder, TestTransactionBuilder},
         db::{
             ordinals_pg::{self, insert_block},
-            pg_test_clear_db, pg_test_connection, pg_test_connection_pool,
+            pg_reset_db, pg_test_connection, pg_test_connection_pool,
         },
     };
 
@@ -200,7 +200,7 @@ mod test {
 
             (next.classic, next.jubilee)
         };
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         Ok(result)
     }
 }

--- a/components/ordhook-core/src/db/ordinals_pg.rs
+++ b/components/ordhook-core/src/db/ordinals_pg.rs
@@ -990,7 +990,7 @@ mod test {
                 self, get_chain_tip_block_height, get_inscriptions_at_block, insert_block,
                 rollback_block,
             },
-            pg_test_clear_db, pg_test_connection, pg_test_connection_pool,
+            pg_reset_db, pg_test_connection, pg_test_connection_pool,
         },
     };
 
@@ -1401,7 +1401,7 @@ mod test {
                 assert_eq!(Some(799999), get_chain_tip_block_height(&client).await?);
             }
         }
-        pg_test_clear_db(&mut pg_client).await;
+        pg_reset_db(&mut pg_client).await;
         Ok(())
     }
 }


### PR DESCRIPTION
Adds the following commands to the CLI:
```
# Runs database migrations
ordhook database migrate --config-path <path>
# Resets database contents and drops all tables
ordhook database reset --config-path <path>
```

These will be adopted by all bitcoin indexers soon, and will allow the API tests to run migrations before each test once it's integrated into this repo.