### PR TITLE
fix(brc20): verify ordinal transfers in chunks instead of individually

### DIFF
--- a/components/chainhook-postgres/src/lib.rs
+++ b/components/chainhook-postgres/src/lib.rs
@@ -7,6 +7,11 @@ pub use tokio_postgres;
 
 use tokio_postgres::{Client, Config, NoTls, Row};
 
+/// Standard chunk size to use when we're batching multiple query inserts into a single SQL statement to save on DB round trips.
+/// This number is designed to not hit the postgres limit of 65536 query parameters in a single SQL statement, but results may
+/// vary depending on column counts. Queries should use other custom chunk sizes as needed.
+pub const BATCH_QUERY_CHUNK_SIZE: usize = 500;
+
 /// A Postgres configuration for a single database.
 #[derive(Clone, Debug)]
 pub struct PgConnectionConfig {

--- a/components/ordhook-core/src/core/meta_protocols/brc20/brc20_pg.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/brc20_pg.rs
@@ -4,7 +4,7 @@ use chainhook_postgres::{
     deadpool_postgres::GenericClient,
     tokio_postgres::{types::ToSql, Client},
     types::{PgNumericU128, PgNumericU64},
-    utils, FromPgRow,
+    utils, FromPgRow, BATCH_QUERY_CHUNK_SIZE,
 };
 use chainhook_sdk::types::{
     BitcoinBlockData, Brc20BalanceData, Brc20Operation, Brc20TokenDeployData, Brc20TransferData,
@@ -87,8 +87,12 @@ pub async fn get_unsent_token_transfers<T: GenericClient>(
         return Ok(vec![]);
     }
     let mut results = vec![];
+    // We can afford a larger chunk size here because we're only using one parameter per ordinal number value.
     for chunk in ordinal_numbers.chunks(5000) {
-        let wrapped: Vec<PgNumericU64> = chunk.iter().map(|n| PgNumericU64(*n)).collect();
+        let mut wrapped = Vec::with_capacity(chunk.len());
+        for n in chunk {
+            wrapped.push(PgNumericU64(*n));
+        }
         let mut params = vec![];
         for number in wrapped.iter() {
             params.push(number);
@@ -121,7 +125,7 @@ pub async fn insert_tokens<T: GenericClient>(
     if tokens.len() == 0 {
         return Ok(());
     }
-    for chunk in tokens.chunks(500) {
+    for chunk in tokens.chunks(BATCH_QUERY_CHUNK_SIZE) {
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
         for row in chunk.iter() {
             params.push(&row.ticker);
@@ -163,7 +167,7 @@ pub async fn insert_operations<T: GenericClient>(
     if operations.len() == 0 {
         return Ok(());
     }
-    for chunk in operations.chunks(500) {
+    for chunk in operations.chunks(BATCH_QUERY_CHUNK_SIZE) {
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
         for row in chunk.iter() {
             params.push(&row.ticker);
@@ -268,7 +272,11 @@ pub async fn update_address_operation_counts<T: GenericClient>(
     if counts.len() == 0 {
         return Ok(());
     }
-    for chunk in counts.keys().collect::<Vec<&String>>().chunks(500) {
+    for chunk in counts
+        .keys()
+        .collect::<Vec<&String>>()
+        .chunks(BATCH_QUERY_CHUNK_SIZE)
+    {
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
         let mut insert_rows = 0;
         for address in chunk {
@@ -302,7 +310,11 @@ pub async fn update_token_operation_counts<T: GenericClient>(
     if counts.len() == 0 {
         return Ok(());
     }
-    for chunk in counts.keys().collect::<Vec<&String>>().chunks(500) {
+    for chunk in counts
+        .keys()
+        .collect::<Vec<&String>>()
+        .chunks(BATCH_QUERY_CHUNK_SIZE)
+    {
         let mut converted = HashMap::new();
         for tick in chunk {
             converted.insert(*tick, counts.get(*tick).unwrap().to_string());
@@ -339,7 +351,11 @@ pub async fn update_token_minted_supplies<T: GenericClient>(
     if supplies.len() == 0 {
         return Ok(());
     }
-    for chunk in supplies.keys().collect::<Vec<&String>>().chunks(500) {
+    for chunk in supplies
+        .keys()
+        .collect::<Vec<&String>>()
+        .chunks(BATCH_QUERY_CHUNK_SIZE)
+    {
         let mut converted = HashMap::new();
         for tick in chunk {
             converted.insert(*tick, supplies.get(*tick).unwrap().0.to_string());

--- a/components/ordhook-core/src/core/meta_protocols/brc20/brc20_pg.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/brc20_pg.rs
@@ -87,7 +87,7 @@ pub async fn get_unsent_token_transfers<T: GenericClient>(
         return Ok(vec![]);
     }
     let mut results = vec![];
-    for chunk in ordinal_numbers.chunks(500) {
+    for chunk in ordinal_numbers.chunks(5000) {
         let wrapped: Vec<PgNumericU64> = chunk.iter().map(|n| PgNumericU64(*n)).collect();
         let mut params = vec![];
         for number in wrapped.iter() {

--- a/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/cache.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::{
+    collections::{HashMap, HashSet},
+    num::NonZeroUsize,
+};
 
 use chainhook_postgres::{
     deadpool_postgres::GenericClient,
@@ -146,30 +149,44 @@ impl Brc20MemoryCache {
         return Ok(None);
     }
 
-    pub async fn get_unsent_token_transfer<T: GenericClient>(
+    pub async fn get_unsent_token_transfers<T: GenericClient>(
         &mut self,
-        ordinal_number: u64,
+        ordinal_numbers: &Vec<&u64>,
         client: &T,
-    ) -> Result<Option<DbOperation>, String> {
-        // Use `get` instead of `contains` so we promote this value in the LRU.
-        if let Some(_) = self.ignored_inscriptions.get(&ordinal_number) {
-            return Ok(None);
-        }
-        if let Some(row) = self.unsent_transfers.get(&ordinal_number) {
-            return Ok(Some(row.clone()));
-        }
-        self.handle_cache_miss(client).await?;
-        match brc20_pg::get_unsent_token_transfer(ordinal_number, client).await? {
-            Some(row) => {
-                self.unsent_transfers.put(ordinal_number, row.clone());
-                return Ok(Some(row));
+    ) -> Result<Vec<DbOperation>, String> {
+        let mut results = vec![];
+        let mut cache_missed_ordinal_numbers = HashSet::new();
+        for ordinal_number in ordinal_numbers.iter() {
+            // Use `get` instead of `contains` so we promote this value in the LRU.
+            if let Some(_) = self.ignored_inscriptions.get(*ordinal_number) {
+                continue;
             }
-            None => {
-                // Inscription is not relevant for BRC20.
-                self.ignore_inscription(ordinal_number);
-                return Ok(None);
+            if let Some(row) = self.unsent_transfers.get(*ordinal_number) {
+                results.push(row.clone());
+            } else {
+                cache_missed_ordinal_numbers.insert(**ordinal_number);
             }
         }
+        if !cache_missed_ordinal_numbers.is_empty() {
+            // Some ordinal numbers were not in cache, check DB.
+            self.handle_cache_miss(client).await?;
+            let pending_transfers = brc20_pg::get_unsent_token_transfers(
+                &cache_missed_ordinal_numbers.iter().cloned().collect(),
+                client,
+            )
+            .await?;
+            for unsent_transfer in pending_transfers.into_iter() {
+                cache_missed_ordinal_numbers.remove(&unsent_transfer.ordinal_number.0);
+                self.unsent_transfers
+                    .put(unsent_transfer.ordinal_number.0, unsent_transfer.clone());
+                results.push(unsent_transfer);
+            }
+            // Ignore all irrelevant numbers.
+            for irrelevant_number in cache_missed_ordinal_numbers.iter() {
+                self.ignore_inscription(*irrelevant_number);
+            }
+        }
+        return Ok(results);
     }
 
     /// Marks an ordinal number as ignored so we don't bother computing its transfers for BRC20 purposes.
@@ -456,12 +473,12 @@ impl Brc20MemoryCache {
             return Ok(transfer.clone());
         }
         self.handle_cache_miss(client).await?;
-        let Some(transfer) = brc20_pg::get_unsent_token_transfer(ordinal_number, client).await?
-        else {
+        let transfers = brc20_pg::get_unsent_token_transfers(&vec![ordinal_number], client).await?;
+        let Some(transfer) = transfers.first() else {
             unreachable!("Invalid transfer ordinal number {}", ordinal_number)
         };
         self.unsent_transfers.put(ordinal_number, transfer.clone());
-        return Ok(transfer);
+        return Ok(transfer.clone());
     }
 
     async fn handle_cache_miss<T: GenericClient>(&mut self, client: &T) -> Result<(), String> {

--- a/components/ordhook-core/src/core/meta_protocols/brc20/index.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/index.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use chainhook_postgres::deadpool_postgres::Transaction;
 use chainhook_sdk::{
     types::{
-        BitcoinBlockData, Brc20BalanceData, Brc20Operation, Brc20TokenDeployData,
-        Brc20TransferData, OrdinalOperation,
+        BitcoinBlockData, BlockIdentifier, Brc20BalanceData, Brc20Operation, Brc20TokenDeployData,
+        Brc20TransferData, OrdinalInscriptionTransferData, OrdinalOperation, TransactionIdentifier,
     },
     utils::Context,
 };
@@ -15,8 +15,63 @@ use super::{
     brc20_activation_height,
     cache::Brc20MemoryCache,
     parser::ParsedBrc20Operation,
-    verifier::{verify_brc20_operation, verify_brc20_transfer, VerifiedBrc20Operation},
+    verifier::{verify_brc20_operation, verify_brc20_transfers, VerifiedBrc20Operation},
 };
+
+async fn index_unverified_brc20_transfers(
+    transfers: &Vec<(&OrdinalInscriptionTransferData, &TransactionIdentifier)>,
+    block_identifier: &BlockIdentifier,
+    timestamp: u32,
+    brc20_cache: &mut Brc20MemoryCache,
+    brc20_db_tx: &Transaction<'_>,
+    ctx: &Context,
+) -> Result<Vec<(usize, Brc20Operation)>, String> {
+    let mut results = vec![];
+    let verified_brc20_transfers =
+        verify_brc20_transfers(transfers, brc20_cache, &brc20_db_tx, &ctx).await?;
+    for (data, transfer, tx_identifier) in verified_brc20_transfers.into_iter() {
+        let Some(token) = brc20_cache.get_token(&data.tick, brc20_db_tx).await? else {
+            unreachable!();
+        };
+        let Some(unsent_transfer) = brc20_cache
+            .get_unsent_token_transfer(transfer.ordinal_number, brc20_db_tx)
+            .await?
+        else {
+            unreachable!();
+        };
+        results.push((
+            transfer.tx_index,
+            Brc20Operation::TransferSend(Brc20TransferData {
+                tick: data.tick.clone(),
+                amt: u128_amount_to_decimals_str(data.amt, token.decimals.0),
+                sender_address: data.sender_address.clone(),
+                receiver_address: data.receiver_address.clone(),
+                inscription_id: unsent_transfer.inscription_id,
+            }),
+        ));
+        brc20_cache
+            .insert_token_transfer_send(
+                &data,
+                &transfer,
+                block_identifier,
+                timestamp,
+                &tx_identifier,
+                transfer.tx_index as u64,
+                brc20_db_tx,
+            )
+            .await?;
+        try_info!(
+            ctx,
+            "BRC-20 transfer_send {} {} ({} -> {}) at block {}",
+            data.tick,
+            data.amt,
+            data.sender_address,
+            data.receiver_address,
+            block_identifier.index
+        );
+    }
+    Ok(results)
+}
 
 /// Indexes BRC-20 operations in a Bitcoin block. Also writes the indexed data to DB.
 pub async fn index_block_and_insert_brc20_operations(
@@ -29,160 +84,92 @@ pub async fn index_block_and_insert_brc20_operations(
     if block.block_identifier.index < brc20_activation_height(&block.metadata.network) {
         return Ok(());
     }
+    // Ordinal transfers that may be brc20 transfers. We group them into a vector to minimize round trips to the db.
+    let mut unverified_ordinal_transfers = vec![];
+    let mut verified_brc20_transfers = vec![];
     for (tx_index, tx) in block.transactions.iter_mut().enumerate() {
         for op in tx.metadata.ordinal_operations.iter() {
             match op {
                 OrdinalOperation::InscriptionRevealed(reveal) => {
-                    if let Some(parsed_brc20_operation) =
+                    let Some(parsed_brc20_operation) =
                         brc20_operation_map.get(&reveal.inscription_id)
-                    {
-                        match verify_brc20_operation(
-                            parsed_brc20_operation,
-                            reveal,
-                            &block.block_identifier,
-                            &block.metadata.network,
-                            brc20_cache,
-                            &brc20_db_tx,
-                            &ctx,
-                        )
-                        .await?
-                        {
-                            Some(VerifiedBrc20Operation::TokenDeploy(token)) => {
-                                tx.metadata.brc20_operation =
-                                    Some(Brc20Operation::Deploy(Brc20TokenDeployData {
-                                        tick: token.tick.clone(),
-                                        max: u128_amount_to_decimals_str(token.max, token.dec),
-                                        lim: u128_amount_to_decimals_str(token.lim, token.dec),
-                                        dec: token.dec.to_string(),
-                                        address: token.address.clone(),
-                                        inscription_id: reveal.inscription_id.clone(),
-                                        self_mint: token.self_mint,
-                                    }));
-                                brc20_cache.insert_token_deploy(
-                                    &token,
-                                    reveal,
-                                    &block.block_identifier,
-                                    block.timestamp,
-                                    &tx.transaction_identifier,
-                                    tx_index as u64,
-                                )?;
-                                try_info!(
-                                    ctx,
-                                    "BRC-20 deploy {} ({}) at block {}",
-                                    token.tick,
-                                    token.address,
-                                    block.block_identifier.index
-                                );
-                            }
-                            Some(VerifiedBrc20Operation::TokenMint(balance)) => {
-                                let Some(token) =
-                                    brc20_cache.get_token(&balance.tick, brc20_db_tx).await?
-                                else {
-                                    unreachable!();
-                                };
-                                tx.metadata.brc20_operation =
-                                    Some(Brc20Operation::Mint(Brc20BalanceData {
-                                        tick: balance.tick.clone(),
-                                        amt: u128_amount_to_decimals_str(
-                                            balance.amt,
-                                            token.decimals.0,
-                                        ),
-                                        address: balance.address.clone(),
-                                        inscription_id: reveal.inscription_id.clone(),
-                                    }));
-                                brc20_cache
-                                    .insert_token_mint(
-                                        &balance,
-                                        reveal,
-                                        &block.block_identifier,
-                                        block.timestamp,
-                                        &tx.transaction_identifier,
-                                        tx_index as u64,
-                                        brc20_db_tx,
-                                    )
-                                    .await?;
-                                try_info!(
-                                    ctx,
-                                    "BRC-20 mint {} {} ({}) at block {}",
-                                    balance.tick,
-                                    balance.amt,
-                                    balance.address,
-                                    block.block_identifier.index
-                                );
-                            }
-                            Some(VerifiedBrc20Operation::TokenTransfer(balance)) => {
-                                let Some(token) =
-                                    brc20_cache.get_token(&balance.tick, brc20_db_tx).await?
-                                else {
-                                    unreachable!();
-                                };
-                                tx.metadata.brc20_operation =
-                                    Some(Brc20Operation::Transfer(Brc20BalanceData {
-                                        tick: balance.tick.clone(),
-                                        amt: u128_amount_to_decimals_str(
-                                            balance.amt,
-                                            token.decimals.0,
-                                        ),
-                                        address: balance.address.clone(),
-                                        inscription_id: reveal.inscription_id.clone(),
-                                    }));
-                                brc20_cache
-                                    .insert_token_transfer(
-                                        &balance,
-                                        reveal,
-                                        &block.block_identifier,
-                                        block.timestamp,
-                                        &tx.transaction_identifier,
-                                        tx_index as u64,
-                                        brc20_db_tx,
-                                    )
-                                    .await?;
-                                try_info!(
-                                    ctx,
-                                    "BRC-20 transfer {} {} ({}) at block {}",
-                                    balance.tick,
-                                    balance.amt,
-                                    balance.address,
-                                    block.block_identifier.index
-                                );
-                            }
-                            Some(VerifiedBrc20Operation::TokenTransferSend(_)) => {
-                                unreachable!("BRC-20 token transfer send should never be generated on reveal")
-                            }
-                            None => {
-                                brc20_cache.ignore_inscription(reveal.ordinal_number);
-                            }
-                        }
-                    } else {
+                    else {
                         brc20_cache.ignore_inscription(reveal.ordinal_number);
-                    }
-                }
-                OrdinalOperation::InscriptionTransferred(transfer) => {
-                    match verify_brc20_transfer(transfer, brc20_cache, &brc20_db_tx, &ctx).await? {
-                        Some(data) => {
+                        continue;
+                    };
+                    // First, verify any pending transfers as they may affect balances for the next operation.
+                    verified_brc20_transfers.append(
+                        &mut index_unverified_brc20_transfers(
+                            &unverified_ordinal_transfers,
+                            &block.block_identifier,
+                            block.timestamp,
+                            brc20_cache,
+                            brc20_db_tx,
+                            ctx,
+                        )
+                        .await?,
+                    );
+                    unverified_ordinal_transfers.clear();
+                    // Then continue with the new operation.
+                    let Some(operation) = verify_brc20_operation(
+                        parsed_brc20_operation,
+                        reveal,
+                        &block.block_identifier,
+                        &block.metadata.network,
+                        brc20_cache,
+                        &brc20_db_tx,
+                        &ctx,
+                    )
+                    .await?
+                    else {
+                        brc20_cache.ignore_inscription(reveal.ordinal_number);
+                        continue;
+                    };
+                    match operation {
+                        VerifiedBrc20Operation::TokenDeploy(token) => {
+                            tx.metadata.brc20_operation =
+                                Some(Brc20Operation::Deploy(Brc20TokenDeployData {
+                                    tick: token.tick.clone(),
+                                    max: u128_amount_to_decimals_str(token.max, token.dec),
+                                    lim: u128_amount_to_decimals_str(token.lim, token.dec),
+                                    dec: token.dec.to_string(),
+                                    address: token.address.clone(),
+                                    inscription_id: reveal.inscription_id.clone(),
+                                    self_mint: token.self_mint,
+                                }));
+                            brc20_cache.insert_token_deploy(
+                                &token,
+                                reveal,
+                                &block.block_identifier,
+                                block.timestamp,
+                                &tx.transaction_identifier,
+                                tx_index as u64,
+                            )?;
+                            try_info!(
+                                ctx,
+                                "BRC-20 deploy {} ({}) at block {}",
+                                token.tick,
+                                token.address,
+                                block.block_identifier.index
+                            );
+                        }
+                        VerifiedBrc20Operation::TokenMint(balance) => {
                             let Some(token) =
-                                brc20_cache.get_token(&data.tick, brc20_db_tx).await?
-                            else {
-                                unreachable!();
-                            };
-                            let Some(unsent_transfer) = brc20_cache
-                                .get_unsent_token_transfer(transfer.ordinal_number, brc20_db_tx)
-                                .await?
+                                brc20_cache.get_token(&balance.tick, brc20_db_tx).await?
                             else {
                                 unreachable!();
                             };
                             tx.metadata.brc20_operation =
-                                Some(Brc20Operation::TransferSend(Brc20TransferData {
-                                    tick: data.tick.clone(),
-                                    amt: u128_amount_to_decimals_str(data.amt, token.decimals.0),
-                                    sender_address: data.sender_address.clone(),
-                                    receiver_address: data.receiver_address.clone(),
-                                    inscription_id: unsent_transfer.inscription_id,
+                                Some(Brc20Operation::Mint(Brc20BalanceData {
+                                    tick: balance.tick.clone(),
+                                    amt: u128_amount_to_decimals_str(balance.amt, token.decimals.0),
+                                    address: balance.address.clone(),
+                                    inscription_id: reveal.inscription_id.clone(),
                                 }));
                             brc20_cache
-                                .insert_token_transfer_send(
-                                    &data,
-                                    &transfer,
+                                .insert_token_mint(
+                                    &balance,
+                                    reveal,
                                     &block.block_identifier,
                                     block.timestamp,
                                     &tx.transaction_identifier,
@@ -192,20 +179,75 @@ pub async fn index_block_and_insert_brc20_operations(
                                 .await?;
                             try_info!(
                                 ctx,
-                                "BRC-20 transfer_send {} {} ({} -> {}) at block {}",
-                                data.tick,
-                                data.amt,
-                                data.sender_address,
-                                data.receiver_address,
+                                "BRC-20 mint {} {} ({}) at block {}",
+                                balance.tick,
+                                balance.amt,
+                                balance.address,
                                 block.block_identifier.index
                             );
                         }
-                        _ => {}
+                        VerifiedBrc20Operation::TokenTransfer(balance) => {
+                            let Some(token) =
+                                brc20_cache.get_token(&balance.tick, brc20_db_tx).await?
+                            else {
+                                unreachable!();
+                            };
+                            tx.metadata.brc20_operation =
+                                Some(Brc20Operation::Transfer(Brc20BalanceData {
+                                    tick: balance.tick.clone(),
+                                    amt: u128_amount_to_decimals_str(balance.amt, token.decimals.0),
+                                    address: balance.address.clone(),
+                                    inscription_id: reveal.inscription_id.clone(),
+                                }));
+                            brc20_cache
+                                .insert_token_transfer(
+                                    &balance,
+                                    reveal,
+                                    &block.block_identifier,
+                                    block.timestamp,
+                                    &tx.transaction_identifier,
+                                    tx_index as u64,
+                                    brc20_db_tx,
+                                )
+                                .await?;
+                            try_info!(
+                                ctx,
+                                "BRC-20 transfer {} {} ({}) at block {}",
+                                balance.tick,
+                                balance.amt,
+                                balance.address,
+                                block.block_identifier.index
+                            );
+                        }
+                        VerifiedBrc20Operation::TokenTransferSend(_) => {
+                            unreachable!(
+                                "BRC-20 token transfer send should never be generated on reveal"
+                            )
+                        }
                     }
+                }
+                OrdinalOperation::InscriptionTransferred(transfer) => {
+                    unverified_ordinal_transfers.push((transfer, &tx.transaction_identifier));
                 }
             }
         }
     }
+    // Verify any dangling ordinal transfers and augment these results back to the block.
+    verified_brc20_transfers.append(
+        &mut index_unverified_brc20_transfers(
+            &unverified_ordinal_transfers,
+            &block.block_identifier,
+            block.timestamp,
+            brc20_cache,
+            brc20_db_tx,
+            ctx,
+        )
+        .await?,
+    );
+    for (tx_index, verified_transfer) in verified_brc20_transfers.into_iter() {
+        block.transactions.get_mut(tx_index).unwrap().metadata.brc20_operation = Some(verified_transfer);
+    }
+    // Write all changes to DB.
     brc20_cache.db_cache.flush(brc20_db_tx).await?;
     Ok(())
 }

--- a/components/ordhook-core/src/core/meta_protocols/brc20/mod.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/mod.rs
@@ -53,6 +53,9 @@ pub fn decimals_str_amount_to_u128(amt: &String, decimals: u8) -> Result<u128, S
 /// Transform a BRC-20 amount which was stored in Postgres as a `u128` back to a `String` with decimals included.
 pub fn u128_amount_to_decimals_str(amount: u128, decimals: u8) -> String {
     let num_str = amount.to_string();
+    if decimals == 0 {
+        return num_str;
+    }
     let decimal_point = num_str.len() as i32 - decimals as i32;
     if decimal_point < 0 {
         let padding = "0".repeat(decimal_point.abs() as usize);

--- a/components/ordhook-core/src/core/meta_protocols/brc20/test_utils.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/test_utils.rs
@@ -98,6 +98,7 @@ pub struct Brc20TransferBuilder {
     pub ordinal_number: u64,
     pub destination: OrdinalInscriptionTransferDestination,
     pub satpoint_post_transfer: String,
+    pub tx_index: usize,
 }
 
 impl Brc20TransferBuilder {
@@ -107,7 +108,8 @@ impl Brc20TransferBuilder {
             destination: OrdinalInscriptionTransferDestination::Transferred(
                 "bc1pls75sfwullhygkmqap344f5cqf97qz95lvle6fvddm0tpz2l5ffslgq3m0".to_string(),
             ),
-            satpoint_post_transfer: "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065d:0:0".to_string()
+            satpoint_post_transfer: "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065d:0:0".to_string(),
+            tx_index: 0,
         }
     }
 
@@ -121,6 +123,11 @@ impl Brc20TransferBuilder {
         self
     }
 
+    pub fn tx_index(mut self, val: usize) -> Self {
+        self.tx_index = val;
+        self
+    }
+
     pub fn build(self) -> OrdinalInscriptionTransferData {
         OrdinalInscriptionTransferData {
             ordinal_number: self.ordinal_number,
@@ -128,7 +135,7 @@ impl Brc20TransferBuilder {
             satpoint_pre_transfer: "".to_string(),
             satpoint_post_transfer: self.satpoint_post_transfer,
             post_transfer_output_value: Some(500),
-            tx_index: 0,
+            tx_index: self.tx_index,
         }
     }
 }

--- a/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
+
 use chainhook_postgres::deadpool_postgres::Transaction;
 use chainhook_sdk::types::{
     BitcoinNetwork, BlockIdentifier, OrdinalInscriptionRevealData, OrdinalInscriptionTransferData,
-    OrdinalInscriptionTransferDestination,
+    OrdinalInscriptionTransferDestination, TransactionIdentifier,
 };
 use chainhook_sdk::utils::Context;
 
@@ -214,49 +216,71 @@ pub async fn verify_brc20_operation(
     };
 }
 
-pub async fn verify_brc20_transfer(
-    transfer: &OrdinalInscriptionTransferData,
+/// Given a list of ordinal transfers, verify which of them are valid `transfer_send` BRC-20 operations we haven't yet processed.
+/// Return verified transfer data for each valid operation.
+pub async fn verify_brc20_transfers(
+    transfers: &Vec<(&TransactionIdentifier, &OrdinalInscriptionTransferData)>,
     cache: &mut Brc20MemoryCache,
     db_tx: &Transaction<'_>,
-    ctx: &Context,
-) -> Result<Option<VerifiedBrc20TransferData>, String> {
-    let Some(transfer_row) = cache
-        .get_unsent_token_transfer(transfer.ordinal_number, db_tx)
-        .await?
-    else {
-        try_debug!(
-            ctx,
-            "BRC-20: No BRC-20 transfer in ordinal {} or transfer already sent",
-            transfer.ordinal_number
-        );
-        return Ok(None);
-    };
-    match &transfer.destination {
-        OrdinalInscriptionTransferDestination::Transferred(receiver_address) => {
-            return Ok(Some(VerifiedBrc20TransferData {
-                tick: transfer_row.ticker.clone(),
-                amt: transfer_row.amount.0,
-                sender_address: transfer_row.address.clone(),
-                receiver_address: receiver_address.to_string(),
-            }));
+    _ctx: &Context,
+) -> Result<
+    Vec<(
+        String,
+        VerifiedBrc20TransferData,
+        OrdinalInscriptionTransferData,
+        TransactionIdentifier,
+    )>,
+    String,
+> {
+    // Select ordinal numbers to analyze for pending BRC20 transfers.
+    let mut ordinal_numbers = vec![];
+    let mut candidate_transfers = HashMap::new();
+    for (tx_identifier, data) in transfers.iter() {
+        if !candidate_transfers.contains_key(&data.ordinal_number) {
+            ordinal_numbers.push(&data.ordinal_number);
+            candidate_transfers.insert(&data.ordinal_number, (*tx_identifier, *data));
         }
-        OrdinalInscriptionTransferDestination::SpentInFees => {
-            return Ok(Some(VerifiedBrc20TransferData {
-                tick: transfer_row.ticker.clone(),
-                amt: transfer_row.amount.0,
-                sender_address: transfer_row.address.clone(),
-                receiver_address: transfer_row.address.clone(), // Return to sender
-            }));
-        }
-        OrdinalInscriptionTransferDestination::Burnt(_) => {
-            return Ok(Some(VerifiedBrc20TransferData {
+    }
+    // Check cache for said transfers.
+    let db_operations = cache
+        .get_unsent_token_transfers(&ordinal_numbers, db_tx)
+        .await?;
+    if db_operations.is_empty() {
+        return Ok(vec![]);
+    }
+    // Return any resulting `transfer_send` operations.
+    let mut results = vec![];
+    for transfer_row in db_operations.into_iter() {
+        let (tx_identifier, data) = candidate_transfers
+            .get(&transfer_row.ordinal_number.0)
+            .unwrap();
+        let verified = match &data.destination {
+            OrdinalInscriptionTransferDestination::Transferred(receiver_address) => {
+                VerifiedBrc20TransferData {
+                    tick: transfer_row.ticker.clone(),
+                    amt: transfer_row.amount.0,
+                    sender_address: transfer_row.address.clone(),
+                    receiver_address: receiver_address.to_string(),
+                }
+            }
+            OrdinalInscriptionTransferDestination::SpentInFees => {
+                VerifiedBrc20TransferData {
+                    tick: transfer_row.ticker.clone(),
+                    amt: transfer_row.amount.0,
+                    sender_address: transfer_row.address.clone(),
+                    receiver_address: transfer_row.address.clone(), // Return to sender
+                }
+            }
+            OrdinalInscriptionTransferDestination::Burnt(_) => VerifiedBrc20TransferData {
                 tick: transfer_row.ticker.clone(),
                 amt: transfer_row.amount.0,
                 sender_address: transfer_row.address.clone(),
                 receiver_address: "".to_string(),
-            }));
-        }
-    };
+            },
+        };
+        results.push((transfer_row.inscription_id, verified, (*data).clone(), (*tx_identifier).clone()));
+    }
+    return Ok(results);
 }
 
 #[cfg(test)]
@@ -282,7 +306,7 @@ mod test {
         db::{pg_test_clear_db, pg_test_connection, pg_test_connection_pool},
     };
 
-    use super::{verify_brc20_operation, verify_brc20_transfer, VerifiedBrc20TransferData};
+    use super::{verify_brc20_operation, verify_brc20_transfers, VerifiedBrc20TransferData};
 
     #[test_case(
         ParsedBrc20Operation::Deploy(ParsedBrc20TokenDeployData {
@@ -863,38 +887,39 @@ mod test {
         let ctx = get_test_ctx();
         let mut pg_client = pg_test_connection().await;
         let _ = brc20_pg::migrate(&mut pg_client).await;
-        let result = {
-            let mut brc20_client = pg_pool_client(&pg_test_connection_pool()).await?;
-            let client = pg_begin(&mut brc20_client).await?;
+        let result =
+            {
+                let mut brc20_client = pg_pool_client(&pg_test_connection_pool()).await?;
+                let client = pg_begin(&mut brc20_client).await?;
 
-            let block = BlockIdentifier {
-                index: 835727,
-                hash: "00000000000000000002d8ba402150b259ddb2b30a1d32ab4a881d4653bceb5b"
-                    .to_string(),
-            };
-            let tx = TransactionIdentifier {
-                hash: "8c8e37ce3ddd869767f8d839d16acc7ea4ec9dd7e3c73afd42a0abb859d7d391"
-                    .to_string(),
-            };
-            let mut cache = Brc20MemoryCache::new(10);
-            cache.insert_token_deploy(
-                &VerifiedBrc20TokenDeployData {
-                    tick: "pepe".to_string(),
-                    display_tick: "pepe".to_string(),
-                    max: 21000000_000000000000000000,
-                    lim: 1000_000000000000000000,
-                    dec: 18,
-                    address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
-                    self_mint: false,
-                },
-                &Brc20RevealBuilder::new().inscription_number(0).build(),
-                &block,
-                0,
-                &tx,
-                0,
-            )?;
-            // Mint from 2 addresses
-            cache.insert_token_mint(
+                let block = BlockIdentifier {
+                    index: 835727,
+                    hash: "00000000000000000002d8ba402150b259ddb2b30a1d32ab4a881d4653bceb5b"
+                        .to_string(),
+                };
+                let tx = TransactionIdentifier {
+                    hash: "8c8e37ce3ddd869767f8d839d16acc7ea4ec9dd7e3c73afd42a0abb859d7d391"
+                        .to_string(),
+                };
+                let mut cache = Brc20MemoryCache::new(10);
+                cache.insert_token_deploy(
+                    &VerifiedBrc20TokenDeployData {
+                        tick: "pepe".to_string(),
+                        display_tick: "pepe".to_string(),
+                        max: 21000000_000000000000000000,
+                        lim: 1000_000000000000000000,
+                        dec: 18,
+                        address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
+                        self_mint: false,
+                    },
+                    &Brc20RevealBuilder::new().inscription_number(0).build(),
+                    &block,
+                    0,
+                    &tx,
+                    0,
+                )?;
+                // Mint from 2 addresses
+                cache.insert_token_mint(
                 &VerifiedBrc20BalanceData {
                     tick: "pepe".to_string(),
                     amt: 1000_000000000000000000,
@@ -912,7 +937,7 @@ mod test {
                 1,
                 &client
             ).await?;
-            cache.insert_token_mint(
+                cache.insert_token_mint(
                 &VerifiedBrc20BalanceData {
                     tick: "pepe".to_string(),
                     amt: 1000_000000000000000000,
@@ -930,17 +955,17 @@ mod test {
                 2,
                 &client
             ).await?;
-            verify_brc20_operation(
-                &op,
-                &reveal,
-                &block,
-                &BitcoinNetwork::Mainnet,
-                &mut cache,
-                &client,
-                &ctx,
-            )
-            .await
-        };
+                verify_brc20_operation(
+                    &op,
+                    &reveal,
+                    &block,
+                    &BitcoinNetwork::Mainnet,
+                    &mut cache,
+                    &client,
+                    &ctx,
+                )
+                .await
+            };
         pg_test_clear_db(&mut pg_client).await;
         result
     }
@@ -993,42 +1018,43 @@ mod test {
         let ctx = get_test_ctx();
         let mut pg_client = pg_test_connection().await;
         let _ = brc20_pg::migrate(&mut pg_client).await;
-        let result = {
-            let mut brc20_client = pg_pool_client(&pg_test_connection_pool()).await?;
-            let client = pg_begin(&mut brc20_client).await?;
+        let result =
+            {
+                let mut brc20_client = pg_pool_client(&pg_test_connection_pool()).await?;
+                let client = pg_begin(&mut brc20_client).await?;
 
-            let block = BlockIdentifier {
-                index: 835727,
-                hash: "00000000000000000002d8ba402150b259ddb2b30a1d32ab4a881d4653bceb5b"
-                    .to_string(),
-            };
-            let tx = TransactionIdentifier {
-                hash: "8c8e37ce3ddd869767f8d839d16acc7ea4ec9dd7e3c73afd42a0abb859d7d391"
-                    .to_string(),
-            };
-            let mut cache = Brc20MemoryCache::new(10);
-            cache.insert_token_deploy(
-                &VerifiedBrc20TokenDeployData {
-                    tick: "pepe".to_string(),
-                    display_tick: "pepe".to_string(),
-                    max: 21000000_000000000000000000,
-                    lim: 1000_000000000000000000,
-                    dec: 18,
-                    address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
-                    self_mint: false,
-                },
-                &Brc20RevealBuilder::new()
-                    .inscription_number(0)
-                    .inscription_id(
-                        "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065di0",
-                    )
-                    .build(),
-                &block,
-                0,
-                &tx,
-                0,
-            )?;
-            cache.insert_token_mint(
+                let block = BlockIdentifier {
+                    index: 835727,
+                    hash: "00000000000000000002d8ba402150b259ddb2b30a1d32ab4a881d4653bceb5b"
+                        .to_string(),
+                };
+                let tx = TransactionIdentifier {
+                    hash: "8c8e37ce3ddd869767f8d839d16acc7ea4ec9dd7e3c73afd42a0abb859d7d391"
+                        .to_string(),
+                };
+                let mut cache = Brc20MemoryCache::new(10);
+                cache.insert_token_deploy(
+                    &VerifiedBrc20TokenDeployData {
+                        tick: "pepe".to_string(),
+                        display_tick: "pepe".to_string(),
+                        max: 21000000_000000000000000000,
+                        lim: 1000_000000000000000000,
+                        dec: 18,
+                        address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
+                        self_mint: false,
+                    },
+                    &Brc20RevealBuilder::new()
+                        .inscription_number(0)
+                        .inscription_id(
+                            "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065di0",
+                        )
+                        .build(),
+                    &block,
+                    0,
+                    &tx,
+                    0,
+                )?;
+                cache.insert_token_mint(
                 &VerifiedBrc20BalanceData {
                     tick: "pepe".to_string(),
                     amt: 1000_000000000000000000,
@@ -1046,7 +1072,7 @@ mod test {
                 1,
                 &client
             ).await?;
-            cache.insert_token_transfer(
+                cache.insert_token_transfer(
                 &VerifiedBrc20BalanceData {
                     tick: "pepe".to_string(),
                     amt: 500_000000000000000000,
@@ -1065,10 +1091,13 @@ mod test {
                 2,
                 &client
             ).await?;
-            verify_brc20_transfer(&transfer, &mut cache, &client, &ctx).await
-        };
+                verify_brc20_transfers(&vec![(&tx, &transfer)], &mut cache, &client, &ctx).await?
+            };
         pg_test_clear_db(&mut pg_client).await;
-        result
+        let Some(result) = result.first() else {
+            return Ok(None);
+        };
+        Ok(Some(result.1.clone()))
     }
 
     #[test_case(
@@ -1083,42 +1112,43 @@ mod test {
         let ctx = get_test_ctx();
         let mut pg_client = pg_test_connection().await;
         let _ = brc20_pg::migrate(&mut pg_client).await;
-        let result = {
-            let mut brc20_client = pg_pool_client(&pg_test_connection_pool()).await?;
-            let client = pg_begin(&mut brc20_client).await?;
+        let result =
+            {
+                let mut brc20_client = pg_pool_client(&pg_test_connection_pool()).await?;
+                let client = pg_begin(&mut brc20_client).await?;
 
-            let block = BlockIdentifier {
-                index: 835727,
-                hash: "00000000000000000002d8ba402150b259ddb2b30a1d32ab4a881d4653bceb5b"
-                    .to_string(),
-            };
-            let tx = TransactionIdentifier {
-                hash: "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065d"
-                    .to_string(),
-            };
-            let mut cache = Brc20MemoryCache::new(10);
-            cache.insert_token_deploy(
-                &VerifiedBrc20TokenDeployData {
-                    tick: "pepe".to_string(),
-                    display_tick: "pepe".to_string(),
-                    max: 21000000_000000000000000000,
-                    lim: 1000_000000000000000000,
-                    dec: 18,
-                    address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
-                    self_mint: false,
-                },
-                &Brc20RevealBuilder::new()
-                    .inscription_number(0)
-                    .inscription_id(
-                        "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065di0",
-                    )
-                    .build(),
-                &block,
-                0,
-                &tx,
-                0,
-            )?;
-            cache.insert_token_mint(
+                let block = BlockIdentifier {
+                    index: 835727,
+                    hash: "00000000000000000002d8ba402150b259ddb2b30a1d32ab4a881d4653bceb5b"
+                        .to_string(),
+                };
+                let tx = TransactionIdentifier {
+                    hash: "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065d"
+                        .to_string(),
+                };
+                let mut cache = Brc20MemoryCache::new(10);
+                cache.insert_token_deploy(
+                    &VerifiedBrc20TokenDeployData {
+                        tick: "pepe".to_string(),
+                        display_tick: "pepe".to_string(),
+                        max: 21000000_000000000000000000,
+                        lim: 1000_000000000000000000,
+                        dec: 18,
+                        address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
+                        self_mint: false,
+                    },
+                    &Brc20RevealBuilder::new()
+                        .inscription_number(0)
+                        .inscription_id(
+                            "e45957c419f130cd5c88cdac3eb1caf2d118aee20c17b15b74a611be395a065di0",
+                        )
+                        .build(),
+                    &block,
+                    0,
+                    &tx,
+                    0,
+                )?;
+                cache.insert_token_mint(
                 &VerifiedBrc20BalanceData {
                     tick: "pepe".to_string(),
                     amt: 1000_000000000000000000,
@@ -1136,7 +1166,7 @@ mod test {
                 1,
                 &client,
             ).await?;
-            cache.insert_token_transfer(
+                cache.insert_token_transfer(
                 &VerifiedBrc20BalanceData {
                     tick: "pepe".to_string(),
                     amt: 500_000000000000000000,
@@ -1155,27 +1185,30 @@ mod test {
                 2,
                 &client,
             ).await?;
-            cache
-                .insert_token_transfer_send(
-                    &VerifiedBrc20TransferData {
-                        tick: "pepe".to_string(),
-                        amt: 500_000000000000000000,
-                        sender_address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
-                        receiver_address:
-                            "bc1pls75sfwullhygkmqap344f5cqf97qz95lvle6fvddm0tpz2l5ffslgq3m0"
-                                .to_string(),
-                    },
-                    &Brc20TransferBuilder::new().ordinal_number(5000).build(),
-                    &block,
-                    3,
-                    &tx,
-                    3,
-                    &client,
-                )
-                .await?;
-            verify_brc20_transfer(&transfer, &mut cache, &client, &ctx).await
-        };
+                cache
+                    .insert_token_transfer_send(
+                        &VerifiedBrc20TransferData {
+                            tick: "pepe".to_string(),
+                            amt: 500_000000000000000000,
+                            sender_address: "324A7GHA2azecbVBAFy4pzEhcPT1GjbUAp".to_string(),
+                            receiver_address:
+                                "bc1pls75sfwullhygkmqap344f5cqf97qz95lvle6fvddm0tpz2l5ffslgq3m0"
+                                    .to_string(),
+                        },
+                        &Brc20TransferBuilder::new().ordinal_number(5000).build(),
+                        &block,
+                        3,
+                        &tx,
+                        3,
+                        &client,
+                    )
+                    .await?;
+                verify_brc20_transfers(&vec![(&tx, &transfer)], &mut cache, &client, &ctx).await?
+            };
         pg_test_clear_db(&mut pg_client).await;
-        result
+        let Some(result) = result.first() else {
+            return Ok(None);
+        };
+        Ok(Some(result.1.clone()))
     }
 }

--- a/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
+++ b/components/ordhook-core/src/core/meta_protocols/brc20/verifier.rs
@@ -222,7 +222,7 @@ pub async fn verify_brc20_transfers(
     transfers: &Vec<(&TransactionIdentifier, &OrdinalInscriptionTransferData)>,
     cache: &mut Brc20MemoryCache,
     db_tx: &Transaction<'_>,
-    _ctx: &Context,
+    ctx: &Context,
 ) -> Result<
     Vec<(
         String,
@@ -232,6 +232,8 @@ pub async fn verify_brc20_transfers(
     )>,
     String,
 > {
+    try_debug!(ctx, "BRC-20 verifying {} ordinal transfers", transfers.len());
+
     // Select ordinal numbers to analyze for pending BRC20 transfers.
     let mut ordinal_numbers = vec![];
     let mut candidate_transfers = HashMap::new();


### PR DESCRIPTION
Some Bitcoin blocks contain tens of thousands (or hundreds of thousands) of ordinal transfers. The BRC-20 indexer needs to look at each of these to see if any `transfer` operation was sent to another address (thus generating a `transfer_send` operation). This is currently extremely slow on our production deployments because it represents 1 roundtrip to postgres for every transfer we need to check.

This PR makes sure that when we analyze these we do so in chunks in order to minimize the roundtrip overhead to and from postgres thus making indexing much faster.