### PR TITLE
chore: unify package versions to workspace.package.version 2.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainhook-postgres"
-version = "0.1.0"
+version = "2.2.5"
 dependencies = [
  "bytes",
  "deadpool-postgres",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "chainhook-sdk"
-version = "0.12.12"
+version = "2.2.5"
 dependencies = [
  "assert-json-diff",
  "base58",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "ordhook"
-version = "1.0.0"
+version = "2.2.5"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "ordhook-cli"
-version = "2.0.0"
+version = "2.2.5"
 dependencies = [
  "chainhook-sdk",
  "chainhook-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ bitcoin = "0.31.2"
 tokio-postgres = "0.7.10"
 deadpool-postgres = "0.14.0"
 refinery = { version = "0.8", features = ["tokio-postgres"] }
+
+[workspace.package]
+version = "2.2.5"

--- a/components/chainhook-postgres/Cargo.toml
+++ b/components/chainhook-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainhook-postgres"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/components/chainhook-sdk/Cargo.toml
+++ b/components/chainhook-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainhook-sdk"
-version = "0.12.12"
+version.workspace = true
 description = "Stateless Transaction Indexing Engine for Stacks and Bitcoin"
 license = "GPL-3.0"
 edition = "2021"

--- a/components/ordhook-cli/Cargo.toml
+++ b/components/ordhook-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordhook-cli"
-version = "2.0.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/components/ordhook-cli/src/cli/mod.rs
+++ b/components/ordhook-cli/src/cli/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use std::{process, u64};
 
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[clap(name = "ordhook", author, version, about, long_about = None)]
 struct Opts {
     #[clap(subcommand)]
     command: Command,

--- a/components/ordhook-core/Cargo.toml
+++ b/components/ordhook-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordhook"
-version = "1.0.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
- fixes https://github.com/hirosystems/ordhook/issues/370