### PR TITLE
fix: remove double parsing of inscriptions

### DIFF
--- a/components/chainhook-sdk/src/indexer/bitcoin/mod.rs
+++ b/components/chainhook-sdk/src/indexer/bitcoin/mod.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use crate::observer::BitcoinConfig;
+use crate::try_debug;
 use crate::utils::Context;
 use bitcoincore_rpc::bitcoin::hashes::Hash;
 use bitcoincore_rpc::bitcoin::{self, Amount, BlockHash};
@@ -342,7 +343,7 @@ pub fn standardize_bitcoin_block(
     let mut transactions = vec![];
     let block_height = block.height as u64;
 
-    ctx.try_log(|logger| slog::debug!(logger, "Standardizing Bitcoin block {}", block.hash,));
+    try_debug!(ctx, "Standardizing Bitcoin block #{} {}", block.height, block.hash);
 
     for (tx_index, mut tx) in block.tx.into_iter().enumerate() {
         let txid = tx.txid.to_string();

--- a/components/ordhook-core/src/core/pipeline/mod.rs
+++ b/components/ordhook-core/src/core/pipeline/mod.rs
@@ -1,8 +1,8 @@
 pub mod processors;
 
 use chainhook_sdk::observer::BitcoinConfig;
-use chainhook_types::BitcoinBlockData;
 use chainhook_sdk::utils::Context;
+use chainhook_types::BitcoinBlockData;
 use crossbeam_channel::bounded;
 use std::collections::{HashMap, VecDeque};
 use std::thread::{sleep, JoinHandle};
@@ -14,10 +14,9 @@ use crate::db::cursor::BlockBytesCursor;
 use crate::{try_debug, try_info};
 
 use chainhook_sdk::indexer::bitcoin::{
-    build_http_client, parse_downloaded_block, try_download_block_bytes_with_retry,
+    build_http_client, parse_downloaded_block, standardize_bitcoin_block,
+    try_download_block_bytes_with_retry,
 };
-
-use super::protocol::inscription_parsing::parse_inscriptions_and_standardize_block;
 
 pub enum PostProcessorCommand {
     ProcessBlocks(Vec<(u64, Vec<u8>)>, Vec<BitcoinBlockData>),
@@ -126,13 +125,13 @@ pub async fn bitcoind_download_blocks(
                         .expect("unable to compress block");
                     let block_height = raw_block_data.height as u64;
                     let block_data = if block_height >= start_sequencing_blocks_at_height {
-                        let block_data = parse_inscriptions_and_standardize_block(
+                        let block = standardize_bitcoin_block(
                             raw_block_data,
                             &moved_bitcoin_network,
                             &moved_ctx,
                         )
                         .expect("unable to deserialize block");
-                        Some(block_data)
+                        Some(block)
                     } else {
                         None
                     };

--- a/components/ordhook-core/src/core/protocol/inscription_parsing.rs
+++ b/components/ordhook-core/src/core/protocol/inscription_parsing.rs
@@ -1,7 +1,5 @@
 use bitcoin::hash_types::Txid;
 use bitcoin::Witness;
-use chainhook_sdk::indexer::bitcoin::BitcoinTransactionFullBreakdown;
-use chainhook_sdk::indexer::bitcoin::{standardize_bitcoin_block, BitcoinBlockFullBreakdown};
 use chainhook_sdk::utils::Context;
 use chainhook_types::{
     BitcoinBlockData, BitcoinNetwork, BitcoinTransactionData, BlockIdentifier,
@@ -9,7 +7,7 @@ use chainhook_types::{
     OrdinalInscriptionRevealData, OrdinalInscriptionTransferData, OrdinalOperation,
 };
 use serde_json::json;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use crate::config::Config;
@@ -153,53 +151,6 @@ pub fn parse_inscriptions_from_standardized_tx(
     operations
 }
 
-pub fn parse_inscriptions_in_raw_tx(
-    tx: &BitcoinTransactionFullBreakdown,
-    _ctx: &Context,
-) -> Vec<OrdinalOperation> {
-    let mut operations = vec![];
-    for (input_index, input) in tx.vin.iter().enumerate() {
-        if let Some(ref witness_data) = input.txinwitness {
-            let witness_bytes: Vec<Vec<u8>> = witness_data
-                .iter()
-                .map(|w| hex::decode(w).unwrap())
-                .collect();
-
-            if let Some(inscriptions) =
-                parse_inscriptions_from_witness(input_index, witness_bytes, &tx.txid)
-            {
-                for (reveal, _inscription) in inscriptions.into_iter() {
-                    operations.push(OrdinalOperation::InscriptionRevealed(reveal));
-                }
-            }
-        }
-    }
-    operations
-}
-
-pub fn parse_inscriptions_and_standardize_block(
-    raw_block: BitcoinBlockFullBreakdown,
-    network: &BitcoinNetwork,
-    ctx: &Context,
-) -> Result<BitcoinBlockData, (String, bool)> {
-    let mut ordinal_operations = BTreeMap::new();
-
-    for tx in raw_block.tx.iter() {
-        ordinal_operations.insert(tx.txid.to_string(), parse_inscriptions_in_raw_tx(&tx, ctx));
-    }
-
-    let mut block = standardize_bitcoin_block(raw_block, network, ctx)?;
-
-    for tx in block.transactions.iter_mut() {
-        if let Some(ordinal_operations) =
-            ordinal_operations.remove(tx.transaction_identifier.get_hash_bytes_str())
-        {
-            tx.metadata.ordinal_operations = ordinal_operations;
-        }
-    }
-    Ok(block)
-}
-
 pub fn parse_inscriptions_in_standardized_block(
     block: &mut BitcoinBlockData,
     brc20_operation_map: &mut HashMap<String, ParsedBrc20Operation>,
@@ -250,17 +201,9 @@ pub fn get_inscriptions_transferred_in_block(
 mod test {
     use std::collections::HashMap;
 
-    use bitcoin::Amount;
-    use chainhook_sdk::{
-        indexer::bitcoin::{
-            BitcoinBlockFullBreakdown, BitcoinTransactionFullBreakdown,
-            BitcoinTransactionInputFullBreakdown, BitcoinTransactionInputPrevoutFullBreakdown,
-            GetRawTransactionResultVinScriptSig,
-        },
-        utils::Context,
-    };
+    use chainhook_sdk::utils::Context;
     use chainhook_types::{
-        BitcoinBlockData, BitcoinNetwork, BitcoinTransactionData, OrdinalInscriptionTransferData,
+        BitcoinBlockData, BitcoinTransactionData, OrdinalInscriptionTransferData,
         OrdinalInscriptionTransferDestination, OrdinalOperation,
     };
     use test_case::test_case;
@@ -272,7 +215,7 @@ mod test {
 
     use super::{
         get_inscriptions_revealed_in_block, get_inscriptions_transferred_in_block,
-        parse_inscriptions_and_standardize_block, parse_inscriptions_in_standardized_block,
+        parse_inscriptions_in_standardized_block,
     };
 
     pub fn new_test_transfer_tx_with_operation() -> BitcoinTransactionData {
@@ -295,43 +238,6 @@ mod test {
                 },
             )])
             .build()
-    }
-
-    pub fn new_test_raw_block(
-        transactions: Vec<BitcoinTransactionFullBreakdown>,
-    ) -> BitcoinBlockFullBreakdown {
-        BitcoinBlockFullBreakdown {
-            hash: "000000000000000000018ddf8a6484db391fb85c9f9ddc384f03a92729423aaf".to_string(),
-            height: 838964,
-            tx: transactions,
-            time: 1712982301,
-            nonce: 100,
-            previousblockhash: Some(
-                "000000000000000000021f8b96d34c0f223281d7d825dd3588c2858c96e689d4".to_string(),
-            ),
-            confirmations: 200,
-        }
-    }
-
-    pub fn new_test_reveal_raw_tx() -> BitcoinTransactionFullBreakdown {
-        BitcoinTransactionFullBreakdown {
-            txid: "b61b0172d95e266c18aea0c624db987e971a5d6d4ebc2aaed85da4642d635735".to_string(),
-            vin: vec![BitcoinTransactionInputFullBreakdown {
-                sequence: 4294967293,
-                txid: Some("a321c61c83563a377f82ef59301f2527079f6bda7c2d04f9f5954c873f42e8ac".to_string()),
-                vout: Some(0),
-                script_sig: Some(GetRawTransactionResultVinScriptSig { hex: "".to_string()}),
-                txinwitness: Some(vec![
-                    "6c00eb3c4d35fedd257051333b4ca81d1a25a37a9af4891f1fec2869edd56b14180eafbda8851d63138a724c9b15384bc5f0536de658bd294d426a36212e6f08".to_string(),
-                    "209e2849b90a2353691fccedd467215c88eec89a5d0dcf468e6cf37abed344d746ac0063036f7264010118746578742f706c61696e3b636861727365743d7574662d38004c5e7b200a20202270223a20226272632d3230222c0a2020226f70223a20226465706c6f79222c0a2020227469636b223a20226f726469222c0a2020226d6178223a20223231303030303030222c0a2020226c696d223a202231303030220a7d68".to_string(),
-                    "c19e2849b90a2353691fccedd467215c88eec89a5d0dcf468e6cf37abed344d746".to_string(),
-                ]),
-                prevout: Some(
-                    BitcoinTransactionInputPrevoutFullBreakdown { height: 779878, value: Amount::from_sat(14830) }
-                ),
-            }],
-            vout: vec![],
-        }
     }
 
     #[test_case(&TestBlockBuilder::new().build() => 0; "with empty block")]
@@ -368,28 +274,6 @@ mod test {
             )
             .build();
         parse_inscriptions_in_standardized_block(&mut block, &mut HashMap::new(), &config, &ctx);
-        let OrdinalOperation::InscriptionRevealed(reveal) =
-            &block.transactions[0].metadata.ordinal_operations[0]
-        else {
-            panic!();
-        };
-        assert_eq!(
-            reveal.inscription_id,
-            "b61b0172d95e266c18aea0c624db987e971a5d6d4ebc2aaed85da4642d635735i0".to_string()
-        );
-        assert_eq!(reveal.content_bytes, "0x7b200a20202270223a20226272632d3230222c0a2020226f70223a20226465706c6f79222c0a2020227469636b223a20226f726469222c0a2020226d6178223a20223231303030303030222c0a2020226c696d223a202231303030220a7d".to_string());
-        assert_eq!(reveal.content_length, 94);
-    }
-
-    #[test]
-    fn parses_inscriptions_in_raw_block() {
-        let raw_block = new_test_raw_block(vec![new_test_reveal_raw_tx()]);
-        let block = parse_inscriptions_and_standardize_block(
-            raw_block,
-            &BitcoinNetwork::Mainnet,
-            &Context::empty(),
-        )
-        .unwrap();
         let OrdinalOperation::InscriptionRevealed(reveal) =
             &block.transactions[0].metadata.ordinal_operations[0]
         else {


### PR DESCRIPTION
We were previously parsing inscription witness data twice: once when downloading blocks from bitcoind and another when actually indexing the block.