### PR TITLE
ci: update package version with semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -21,6 +21,12 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@version = \"[^\"]*\"@version = \"${nextRelease.version}\"@g' Cargo.toml Cargo.lock"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "successComment": false

--- a/.releaserc
+++ b/.releaserc
@@ -23,7 +23,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@[workspace.package]\\nversion = \"[^\"]*\"@[workspace.package]\\nversion = \"${nextRelease.version}\"@g' Cargo.toml && sed -i -e '1h;2,$H;$!d;g' -e 's@name = \"cli\"\\nversion = \"[^\"]*\"@name = \"cli\"\\nversion = \"${nextRelease.version}\"@g' Cargo.lock"
+        "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@\\[workspace\\.package\\]\\nversion = \"[^\"]*\"@\\[workspace\\.package\\]\\nversion = \"${nextRelease.version}\"@g' Cargo.toml && sed -i -e '1h;2,$H;$!d;g' -e 's@name = \"cli\"\\nversion = \"[^\"]*\"@name = \"cli\"\\nversion = \"${nextRelease.version}\"@g' Cargo.lock"
       }
     ],
     [

--- a/.releaserc
+++ b/.releaserc
@@ -23,7 +23,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@version = \"[^\"]*\"@version = \"${nextRelease.version}\"@g' Cargo.toml Cargo.lock"
+        "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@[workspace.package]\\nversion = \"[^\"]*\"@[workspace.package]\\nversion = \"${nextRelease.version}\"@g' Cargo.toml && sed -i -e '1h;2,$H;$!d;g' -e 's@name = \"cli\"\\nversion = \"[^\"]*\"@name = \"cli\"\\nversion = \"${nextRelease.version}\"@g' Cargo.lock"
       }
     ],
     [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aligned-vec"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af15ccceeacb9304119d97925de463bc97ae3555ee8dc8056f67b119f66e5934"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
 ]
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.87"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -465,7 +465,7 @@ dependencies = [
  "hex",
  "hiro-system-kit",
  "lazy_static",
- "reqwest 0.12.14",
+ "reqwest 0.12.15",
  "rocket",
  "schemars",
  "serde",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1247,9 +1247,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1396,14 +1396,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1439,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1711,7 +1713,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.23",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -2076,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2093,9 +2095,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
@@ -2612,7 +2614,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2712,34 +2714,36 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.23",
+ "rustls 0.23.25",
  "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom 0.3.2",
+ "rand 0.9.0",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.23",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -2772,6 +2776,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,7 +2800,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -2828,7 +2838,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -3025,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3048,7 +3058,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.23",
+ "rustls 0.23.25",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3244,14 +3254,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.2",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -3269,14 +3279,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.23"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.0",
  "subtle",
  "zeroize",
 ]
@@ -3320,9 +3330,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3919,15 +3929,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.18.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.2",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -4051,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -4066,15 +4075,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4176,7 +4185,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.23",
+ "rustls 0.23.25",
  "tokio",
 ]
 
@@ -4443,9 +4452,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 
 [[package]]
 name = "valuable"
@@ -4498,9 +4507,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -4704,9 +4713,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
@@ -4721,9 +4730,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
  "windows-link",
 ]
@@ -4970,9 +4979,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -4996,7 +5005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.2",
+ "rustix 1.0.3",
 ]
 
 [[package]]
@@ -5043,11 +5052,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -5063,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "2.2.5"
+version = "1.0.0"
 dependencies = [
  "assert-json-diff",
  "base58",
@@ -726,7 +726,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cli"
-version = "2.2.5"
+version = "3.0.0"
 dependencies = [
  "bitcoind",
  "clap 3.2.25",
@@ -736,7 +736,7 @@ dependencies = [
  "hex",
  "hiro-system-kit",
  "num_cpus",
- "ordinals 2.2.5",
+ "ordinals 1.0.0",
  "reqwest 0.11.27",
  "runes",
  "serde",
@@ -754,7 +754,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "config"
-version = "2.2.5"
+version = "1.0.0"
 dependencies = [
  "bitcoin 0.32.5",
  "hiro-system-kit",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "ordinals"
-version = "2.2.5"
+version = "1.0.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2539,7 +2539,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "postgres"
-version = "2.2.5"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "config",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "runes"
-version = "2.2.5"
+version = "1.0.0"
 dependencies = [
  "bitcoin 0.32.5",
  "bitcoind",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ tokio = { version = "1.38.1", features = ["full"] }
 tokio-postgres = "0.7.10"
 
 [workspace.package]
-version = "2.2.5"
+version = "3.0.0"

--- a/components/bitcoind/Cargo.toml
+++ b/components/bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind"
-version.workspace = true
+version = "1.0.0"
 description = "Stateless Transaction Indexing Engine for Bitcoin"
 license = "GPL-3.0"
 edition = "2021"

--- a/components/cli/src/cli/commands.rs
+++ b/components/cli/src/cli/commands.rs
@@ -1,16 +1,16 @@
 use clap::{Parser, Subcommand};
 
-/// Protocol command enum
+/// Index Bitcoin meta-protocols like Ordinals, BRC-20, and Runes
 #[derive(Parser, Debug)]
 #[clap(name = "bitcoin-indexer", author, version, about, long_about = None)]
 pub enum Protocol {
-    /// Ordinals commands
+    /// Ordinals index commands
     #[clap(subcommand)]
     Ordinals(Command),
-    /// Runes commands
+    /// Runes index commands
     #[clap(subcommand)]
     Runes(Command),
-    /// Generate a new configuration file
+    /// Configuration file commands
     #[clap(subcommand)]
     Config(ConfigCommand),
 }

--- a/components/config/Cargo.toml
+++ b/components/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config"
-version.workspace = true
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/components/ordinals/Cargo.toml
+++ b/components/ordinals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ordinals"
-version.workspace = true
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/components/postgres/Cargo.toml
+++ b/components/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres"
-version.workspace = true
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/components/runes/Cargo.toml
+++ b/components/runes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runes"
-version.workspace = true
+version = "1.0.0"
 edition = "2021"
 
 [dependencies]

--- a/components/runes/Cargo.toml
+++ b/components/runes/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 bitcoind = { path = "../bitcoind" }
 bitcoin = { workspace = true }
 lru = "0.12.3"
-ordinals = "0.0.15"
+ordinals-parser = { package = "ordinals", version = "0.0.15" }
 bytes = "1.3"
 config = { path = "../config" }
 serde = "1"

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -4,7 +4,7 @@ use bitcoin::{Network, ScriptBuf};
 use bitcoind::{try_debug, try_info, try_warn, types::bitcoin::TxIn, utils::Context};
 use config::Config;
 use lru::LruCache;
-use ordinals::{Cenotaph, Edict, Etching, Rune, RuneId, Runestone};
+use ordinals_parser::{Cenotaph, Edict, Etching, Rune, RuneId, Runestone};
 use tokio_postgres::{Client, Transaction};
 
 use super::{

--- a/components/runes/src/db/cache/transaction_cache.rs
+++ b/components/runes/src/db/cache/transaction_cache.rs
@@ -5,7 +5,7 @@ use std::{
 
 use bitcoin::ScriptBuf;
 use bitcoind::{try_debug, try_info, try_warn, utils::Context};
-use ordinals::{Cenotaph, Edict, Etching, Rune, RuneId};
+use ordinals_parser::{Cenotaph, Edict, Etching, Rune, RuneId};
 
 use super::{
     input_rune_balance::InputRuneBalance, transaction_location::TransactionLocation,
@@ -405,7 +405,7 @@ mod test {
     use bitcoin::ScriptBuf;
     use bitcoind::utils::Context;
     use maplit::hashmap;
-    use ordinals::{Edict, Etching, Rune, Terms};
+    use ordinals_parser::{Edict, Etching, Rune, Terms};
 
     use super::TransactionCache;
     use crate::db::{

--- a/components/runes/src/db/cache/transaction_location.rs
+++ b/components/runes/src/db/cache/transaction_location.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use bitcoin::Network;
-use ordinals::RuneId;
+use ordinals_parser::RuneId;
 
 #[derive(Debug, Clone)]
 pub struct TransactionLocation {

--- a/components/runes/src/db/cache/utils.rs
+++ b/components/runes/src/db/cache/utils.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use bitcoin::{Address, ScriptBuf};
 use bitcoind::{try_info, try_warn, types::bitcoin::TxIn, utils::Context};
 use lru::LruCache;
-use ordinals::RuneId;
+use ordinals_parser::RuneId;
 use tokio_postgres::Transaction;
 
 use super::{input_rune_balance::InputRuneBalance, transaction_location::TransactionLocation};
@@ -314,7 +314,7 @@ mod test {
         use bitcoin::ScriptBuf;
         use bitcoind::utils::Context;
         use maplit::hashmap;
-        use ordinals::RuneId;
+        use ordinals_parser::RuneId;
 
         use crate::db::{
             cache::{
@@ -630,7 +630,7 @@ mod test {
     }
 
     mod sequential_ledger_entry {
-        use ordinals::RuneId;
+        use ordinals_parser::RuneId;
 
         use crate::db::{
             cache::{
@@ -691,7 +691,7 @@ mod test {
         };
         use lru::LruCache;
         use maplit::hashmap;
-        use ordinals::RuneId;
+        use ordinals_parser::RuneId;
 
         use crate::db::{
             cache::{
@@ -900,7 +900,7 @@ mod test {
 
         use lru::LruCache;
         use maplit::hashmap;
-        use ordinals::RuneId;
+        use ordinals_parser::RuneId;
 
         use crate::db::cache::{
             input_rune_balance::InputRuneBalance, utils::move_block_output_cache_to_output_cache,

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -10,7 +10,7 @@ use bitcoind::{
     types::{BitcoinBlockData, BitcoinTransactionData},
     utils::Context,
 };
-use ordinals::{Artifact, Runestone};
+use ordinals_parser::{Artifact, Runestone};
 use tokio_postgres::Client;
 
 use super::cache::index_cache::IndexCache;

--- a/components/runes/src/db/mod.rs
+++ b/components/runes/src/db/mod.rs
@@ -7,7 +7,7 @@ use models::{
     db_balance_change::DbBalanceChange, db_ledger_entry::DbLedgerEntry, db_rune::DbRune,
     db_supply_change::DbSupplyChange,
 };
-use ordinals::RuneId;
+use ordinals_parser::RuneId;
 use postgres::types::{PgBigIntU32, PgNumericU128, PgNumericU64};
 use refinery::embed_migrations;
 use tokio_postgres::{types::ToSql, Client, Error, GenericClient, NoTls, Transaction};

--- a/components/runes/src/db/models/db_ledger_entry.rs
+++ b/components/runes/src/db/models/db_ledger_entry.rs
@@ -1,4 +1,4 @@
-use ordinals::RuneId;
+use ordinals_parser::RuneId;
 use postgres::types::{PgBigIntU32, PgNumericU128, PgNumericU64};
 use tokio_postgres::Row;
 

--- a/components/runes/src/db/models/db_rune.rs
+++ b/components/runes/src/db/models/db_rune.rs
@@ -1,4 +1,4 @@
-use ordinals::{Etching, Rune, RuneId, SpacedRune};
+use ordinals_parser::{Etching, Rune, RuneId, SpacedRune};
 use postgres::types::{PgBigIntU32, PgNumericU128, PgNumericU64, PgSmallIntU8};
 use tokio_postgres::Row;
 
@@ -204,7 +204,7 @@ impl DbRune {
 mod test {
     use std::str::FromStr;
 
-    use ordinals::{Etching, SpacedRune, Terms};
+    use ordinals_parser::{Etching, SpacedRune, Terms};
 
     use super::DbRune;
     use crate::db::cache::transaction_location::TransactionLocation;


### PR DESCRIPTION
* Update package version with semantic release
* Only version `cli` package to simplify commands
* Alias `ordinals` dependency on runes to `ordinals-parser` to avoid confusion

Fixes #419 