### PR TITLE
ci: update semantic release permissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,6 @@
 /dockerfiles/
 node_modules/
 tmp/
+.vercel
+.github
+.vscode

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,6 +313,9 @@ jobs:
     outputs:
       docker_image_digest: ${{ steps.docker_push.outputs.digest }}
     steps:
+      - name: Debug the output
+        run: echo "The output is ${{ needs.semantic-release.outputs.new_release_published }} ${{ needs.semantic-release.outputs.latest }}"
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,7 +278,7 @@ jobs:
 
   semantic-release:
     runs-on: ubuntu-latest
-    # needs: [api-lint, api-test, test, rustfmt, clippy]
+    needs: [api-lint, api-test, test, rustfmt, clippy]
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -284,7 +284,7 @@ jobs:
       issues: write
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
-      new_release_published: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       latest: ${{ steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
@@ -374,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout tag
-        if: needs.semantic-release.outputs.new_release_version != ''
+        if: needs.semantic-release.outputs.new_release_published
         uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,6 +279,9 @@ jobs:
   semantic-release:
     runs-on: ubuntu-latest
     needs: [api-lint, api-test, test, rustfmt, clippy]
+    permissions:
+      contents: write
+      issues: write
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
@@ -368,7 +371,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -409,125 +412,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
           push: ${{ (github.ref != 'refs/heads/master' || needs.semantic-release.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-
-  deploy-dev:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        network: [mainnet]
-        subenv: [blue]
-    needs: build-publish
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    env:
-      DEPLOY_ENV: dev
-    environment:
-      name: Development-${{ matrix.network }}-${{ matrix.subenv }}
-      url: https://platform.dev.hiro.so/
-    steps:
-      - name: Checkout actions repo
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GH_TOKEN }}
-          repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
-
-      - name: Deploy Ordhook build to Dev ${{ matrix.network }} ${{ matrix.subenv }}
-        uses: ./actions/deploy
-        with:
-          docker_image: ${{ env.DOCKER_IMAGE }}
-          docker_image_tag_or_digest: ${{ needs.build-publish.outputs.docker_image_digest }}
-          file_pattern: manifests/bitcoin/${{ matrix.network }}/ordhook/${{ env.DEPLOY_ENV }}/*/kustomization.yaml
-          subenv: ${{ matrix.subenv }}
-          gh_token: ${{ secrets.GH_TOKEN }}
-
-  auto-approve-dev:
-    runs-on: ubuntu-latest
-    if: needs.build-publish.outputs.new_release_published == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    needs: build-publish
-    steps:
-      - name: Approve pending deployments
-        run: |
-          sleep 5
-          ENV_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/ordhook/actions/runs/${{ github.run_id }}/pending_deployments" | jq -r '.[0].environment.id // empty')
-          if [[ "${ENV_IDS}" != "[]" ]]; then
-            curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/ordhook/actions/runs/${{ github.run_id }}/pending_deployments" -d "{\"environment_ids\":[${ENV_ID}],\"state\":\"approved\",\"comment\":\"auto approve\"}"
-          fi
-
-  deploy-staging:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        network: [mainnet]
-        subenv: [blue]
-    needs:
-      - build-publish
-      - deploy-dev
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    env:
-      DEPLOY_ENV: stg
-    environment:
-      name: Staging-${{ matrix.network }}-${{ matrix.subenv }}
-      url: https://platform.stg.hiro.so/
-    steps:
-      - name: Checkout actions repo
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GH_TOKEN }}
-          repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
-
-      - name: Deploy Ordhook build to Stg ${{ matrix.network }} ${{ matrix.subenv }}
-        uses: ./actions/deploy
-        with:
-          docker_image: ${{ env.DOCKER_IMAGE }}
-          docker_image_tag_or_digest: ${{ needs.build-publish.outputs.docker_image_digest }}
-          file_pattern: manifests/bitcoin/${{ matrix.network }}/ordhook/${{ env.DEPLOY_ENV }}/*/kustomization.yaml
-          subenv: ${{ matrix.subenv }}
-          gh_token: ${{ secrets.GH_TOKEN }}
-
-  auto-approve-stg:
-    runs-on: ubuntu-latest
-    if: needs.build-publish.outputs.new_release_published == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    needs:
-      - build-publish
-      - deploy-dev
-    steps:
-      - name: Approve pending deployments
-        run: |
-          sleep 5
-          ENV_ID=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/ordhook/actions/runs/${{ github.run_id }}/pending_deployments" | jq -r '.[0].environment.id // empty')
-          if [[ "${ENV_IDS}" != "[]" ]]; then
-            curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/hirosystems/ordhook/actions/runs/${{ github.run_id }}/pending_deployments" -d "{\"environment_ids\":[${ENV_ID}],\"state\":\"approved\",\"comment\":\"auto approve\"}"
-          fi
-
-  deploy-prod:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        network: [mainnet]
-        subenv: [blue, green]
-    needs:
-      - build-publish
-      - deploy-staging
-    if: needs.build-publish.outputs.new_release_published == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-    env:
-      DEPLOY_ENV: prd
-    environment:
-      name: Production-${{ matrix.network }}-${{ matrix.subenv }}
-      url: https://platform.hiro.so/
-    steps:
-      - name: Checkout actions repo
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          token: ${{ secrets.GH_TOKEN }}
-          repository: ${{ secrets.DEVOPS_ACTIONS_REPO }}
-
-      - name: Deploy Ordhook build to Prd ${{ matrix.network }} ${{ matrix.subenv }}
-        uses: ./actions/deploy
-        with:
-          docker_image: ${{ env.DOCKER_IMAGE }}
-          docker_image_tag_or_digest: ${{ needs.build-publish.outputs.docker_image_digest }}
-          file_pattern: manifests/bitcoin/${{ matrix.network }}/ordhook/${{ env.DEPLOY_ENV }}/*/kustomization.yaml
-          subenv: ${{ matrix.subenv }}
-          gh_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -284,8 +284,8 @@ jobs:
       issues: write
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
-      new_release_published: ${{ steps.semantic.outputs.new_release_version != '' }}
-      latest: ${{ steps.semantic.outputs.new_release_version != '' && github.ref_name == 'main' }}
+      new_release_published: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+      latest: ${{ steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -313,8 +313,19 @@ jobs:
     outputs:
       docker_image_digest: ${{ steps.docker_push.outputs.digest }}
     steps:
-      - name: Debug the output
-        run: echo "The output is ${{ needs.semantic-release.outputs.new_release_published }} ${{ needs.semantic-release.outputs.latest }}"
+      - name: Debug output
+        run: |
+          VALUE="${{ needs.semantic-release.outputs.new_release_published }}"
+          echo "new_release_published is: '$VALUE'"
+          if [ "$VALUE" = "false" ]; then
+            echo "Value is the string 'false'"
+          elif [ "$VALUE" = "true" ]; then
+            echo "Value is the string 'true'"
+          elif [ -z "$VALUE" ]; then
+            echo "Value is empty or unset"
+          else
+            echo "Value is something else: '$VALUE'"
+          fi
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,14 +278,14 @@ jobs:
 
   semantic-release:
     runs-on: ubuntu-latest
-    needs: [api-lint, api-test, test, rustfmt, clippy]
+    # needs: [api-lint, api-test, test, rustfmt, clippy]
     permissions:
       contents: write
       issues: write
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      latest: ${{ steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'main' }}
+      new_release_published: ${{ steps.semantic.outputs.new_release_version != '' }}
+      latest: ${{ steps.semantic.outputs.new_release_version != '' && github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -357,7 +357,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_published) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
   api-build-publish:
     strategy:
@@ -410,4 +410,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-          push: ${{ (github.ref != 'refs/heads/master' || needs.semantic-release.outputs.new_release_version != '') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_published) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -284,7 +284,7 @@ jobs:
       issues: write
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
-      new_release_published: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       latest: ${{ steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
@@ -313,26 +313,12 @@ jobs:
     outputs:
       docker_image_digest: ${{ steps.docker_push.outputs.digest }}
     steps:
-      - name: Debug output
-        run: |
-          VALUE="${{ needs.semantic-release.outputs.new_release_published }}"
-          echo "new_release_published is: '$VALUE'"
-          if [ "$VALUE" = "false" ]; then
-            echo "Value is the string 'false'"
-          elif [ "$VALUE" = "true" ]; then
-            echo "Value is the string 'true'"
-          elif [ -z "$VALUE" ]; then
-            echo "Value is empty or unset"
-          else
-            echo "Value is something else: '$VALUE'"
-          fi
-
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
       - name: Checkout tag
-        if: needs.semantic-release.outputs.new_release_published
+        if: needs.semantic-release.outputs.new_release_published == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -371,7 +357,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_published) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_published == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
 
   api-build-publish:
     strategy:
@@ -388,7 +374,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout tag
-        if: needs.semantic-release.outputs.new_release_published
+        if: needs.semantic-release.outputs.new_release_published == 'true'
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -424,4 +410,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
-          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_published) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+          push: ${{ (github.ref != 'refs/heads/main' || needs.semantic-release.outputs.new_release_published == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -284,7 +284,8 @@ jobs:
       issues: write
     outputs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_published: ${{ steps.semantic.outputs.new_release_published == 'true' }}
+      latest: ${{ steps.semantic.outputs.new_release_published == 'true' && github.ref_name == 'main' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -298,7 +299,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_CRATES_IO_API_KEY }}
         with:
           semantic_version: 19
           extra_plugins: |
@@ -318,7 +318,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout tag
-        if: needs.semantic-release.outputs.new_release_version != ''
+        if: needs.semantic-release.outputs.new_release_published
         uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -336,9 +336,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_version != '' }}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_published }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_published }}
+            type=raw,value=latest,enable=${{ needs.semantic-release.outputs.latest }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
@@ -354,8 +354,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ./dockerfiles/components/bitcoin-indexer.dockerfile
-          build-args: |
-            GIT_COMMIT=${{ env.GITHUB_SHA_SHORT }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Only push if (there's a new release on main branch, or if building a non-main branch) and (Only run on non-PR events or only PRs that aren't from forks)
@@ -394,8 +392,9 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_version != '' }}
+            type=semver,pattern={{version}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_published }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.semantic-release.outputs.new_release_version }},enable=${{ needs.semantic-release.outputs.new_release_published }}
+            type=raw,value=latest,enable=${{ needs.semantic-release.outputs.latest }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,7 +1,6 @@
 name: Vercel
 
 env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 on:

--- a/.github/workflows/vercel.yml
+++ b/.github/workflows/vercel.yml
@@ -1,6 +1,7 @@
 name: Vercel
 
 env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 on:

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ Cargo.lock
 # Mutation Testing
 mutants.out/
 mutants.out.old/
+.vercel

--- a/components/cli/build.rs
+++ b/components/cli/build.rs
@@ -1,29 +1,3 @@
-use std::process::Command;
-
-fn current_git_hash() -> Option<String> {
-    if option_env!("GIT_COMMIT").is_none() {
-        let commit = Command::new("git")
-            .arg("log")
-            .arg("-1")
-            .arg("--pretty=format:%h") // Abbreviated commit hash
-            .current_dir(env!("CARGO_MANIFEST_DIR"))
-            .output();
-
-        if let Ok(commit) = commit {
-            if let Ok(commit) = String::from_utf8(commit.stdout) {
-                return Some(commit);
-            }
-        }
-    } else {
-        return option_env!("GIT_COMMIT").map(String::from);
-    }
-
-    None
-}
-
 fn main() {
     // note: add error checking yourself.
-    if let Some(git) = current_git_hash() {
-        println!("cargo:rustc-env=GIT_COMMIT={}", git);
-    }
 }

--- a/dockerfiles/components/bitcoin-indexer.dockerfile
+++ b/dockerfiles/components/bitcoin-indexer.dockerfile
@@ -1,9 +1,5 @@
 FROM rust:bullseye AS build
 
-ARG GIT_COMMIT='0000000'
-
-ENV GIT_COMMIT=${GIT_COMMIT}
-
 WORKDIR /src
 
 RUN apt-get update && apt-get install -y ca-certificates pkg-config libssl-dev libclang-11-dev libunwind-dev libunwind8 curl gnupg


### PR DESCRIPTION
@CharlieC3 I also removed the old deployment jobs to dev/stg/prd because they worked with the old ordhook and now they're obsolete

* Removes old GIT_HASH docker build arg
* Only tags `latest` for images released against main branch