### PR TITLE
fix: wait idefinitely for zmq blocks to arrive

### DIFF
--- a/components/bitcoind/src/indexer/mod.rs
+++ b/components/bitcoind/src/indexer/mod.rs
@@ -5,8 +5,7 @@ pub mod fork_scratch_pad;
 use std::{
     collections::{HashMap, VecDeque},
     sync::{Arc, Mutex},
-    thread::{sleep, JoinHandle},
-    time::Duration,
+    thread::JoinHandle,
 };
 
 use bitcoin::{
@@ -14,7 +13,7 @@ use bitcoin::{
     pipeline::start_block_download_pipeline, standardize_bitcoin_block,
 };
 use config::Config;
-use crossbeam_channel::{Receiver, Sender, TryRecvError};
+use crossbeam_channel::{Receiver, Sender};
 use reqwest::Client;
 
 use self::fork_scratch_pad::ForkScratchPad;

--- a/components/bitcoind/src/indexer/mod.rs
+++ b/components/bitcoind/src/indexer/mod.rs
@@ -235,35 +235,17 @@ async fn block_ingestion_runloop(
         }
     }
 
-    let mut empty_cycles = 0;
     loop {
-        let (compacted_blocks, blocks) = match block_commands_rx.try_recv() {
+        let (compacted_blocks, blocks) = match block_commands_rx.recv() {
             Ok(BlockProcessorCommand::ProcessBlocks {
                 compacted_blocks,
                 blocks,
-            }) => {
-                empty_cycles = 0;
-                (compacted_blocks, blocks)
-            }
+            }) => (compacted_blocks, blocks),
             Ok(BlockProcessorCommand::Terminate) => {
                 let _ = block_events_tx.send(BlockProcessorEvent::Terminated);
                 return Ok(());
             }
-            Err(e) => match e {
-                TryRecvError::Empty => {
-                    empty_cycles += 1;
-                    if empty_cycles == 180 {
-                        try_info!(ctx, "Block processor reached expiration");
-                        let _ = block_events_tx.send(BlockProcessorEvent::Expired);
-                        return Ok(());
-                    }
-                    sleep(Duration::from_secs(1));
-                    continue;
-                }
-                _ => {
-                    return Ok(());
-                }
-            },
+            Err(e) => return Err(format!("block ingestion runloop error: {e}")),
         };
 
         if !compacted_blocks.is_empty() {

--- a/components/ordinals/src/lib.rs
+++ b/components/ordinals/src/lib.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, thread::JoinHandle};
 
 use bitcoind::{
     indexer::{start_bitcoin_indexer, Indexer, IndexerCommand},
-    try_debug,
+    try_debug, try_error,
     types::BlockIdentifier,
     utils::{future_block_on, Context},
 };
@@ -137,7 +137,7 @@ async fn new_ordinals_indexer_runloop(
                                 }
                             }
                         },
-                        Err(_) => todo!(),
+                        Err(e) => return Err(format!("ordinals indexer channel error: {e}")),
                     }
                 }
             });

--- a/components/ordinals/src/lib.rs
+++ b/components/ordinals/src/lib.rs
@@ -12,7 +12,7 @@ use std::{sync::Arc, thread::JoinHandle};
 
 use bitcoind::{
     indexer::{start_bitcoin_indexer, Indexer, IndexerCommand},
-    try_debug, try_error,
+    try_debug,
     types::BlockIdentifier,
     utils::{future_block_on, Context},
 };


### PR DESCRIPTION
Instead of waiting only 3 minutes for new blocks to arrive via ZeroMQ, block the ingestion thread indefinitely until a new block arrives.

Fixes #523 