### PR TITLE
fix(runes): validations and cenotaph tracking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "rust-analyzer.rustfmt.extraArgs": [
         "--config",
         "group_imports=StdExternalCrate,imports_granularity=Crate"
-    ]
+    ],
+    "rust-analyzer.checkOnSave": true
 }

--- a/components/bitcoind/src/utils/bitcoind.rs
+++ b/components/bitcoind/src/utils/bitcoind.rs
@@ -71,27 +71,13 @@ pub fn bitcoin_get_raw_transaction(
     bitcoin_rpc: &Client,
     ctx: &Context,
     txid: &Txid,
-) -> Option<GetRawTransactionResult> {
-    let mut tries = 0;
-    loop {
-        match bitcoin_rpc.get_raw_transaction_info(txid, None) {
-            Ok(result) => {
-                return Some(result);
-            }
-            Err(e) => {
-                tries += 1;
-                if tries > 10 {
-                    return None;
-                }
-                try_error!(
-                    ctx,
-                    "bitcoind: Unable to get raw transaction: {}",
-                    e.to_string()
-                );
-                sleep(Duration::from_secs(1));
-            }
-        };
-    }
+) -> Result<GetRawTransactionResult, String> {
+    bitcoin_rpc
+        .get_raw_transaction_info(txid, None)
+        .map_err(|e| {
+            try_error!(ctx, "bitcoind: Unable to get raw transaction: {e}",);
+            e.to_string()
+        })
 }
 
 /// Checks if bitcoind is still synchronizing blocks and waits until it's finished if that is the case.

--- a/components/bitcoind/src/utils/bitcoind.rs
+++ b/components/bitcoind/src/utils/bitcoind.rs
@@ -52,22 +52,18 @@ pub fn bitcoind_get_block_height(
     bitcoin_rpc: &Client,
     ctx: &Context,
     blockhash: &BlockHash,
-) -> u32 {
-    loop {
-        match bitcoin_rpc.get_block_header_info(blockhash) {
-            Ok(result) => {
-                return result.height.try_into().unwrap();
-            }
-            Err(e) => {
-                try_error!(
-                    ctx,
-                    "bitcoind: Unable to get block header info: {}",
-                    e.to_string()
-                );
-                sleep(Duration::from_secs(1));
-            }
-        };
-    }
+) -> Result<u32, String> {
+    bitcoin_rpc
+        .get_block_header_info(blockhash)
+        .map(|result| result.height.try_into().unwrap())
+        .map_err(|e| {
+            try_error!(
+                ctx,
+                "bitcoind: Unable to get block header info: {}",
+                e.to_string()
+            );
+            e.to_string()
+        })
 }
 
 /// Retrieves the raw transaction for a given txid.

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -19,8 +19,7 @@ use super::{
 };
 use crate::db::{
     cache::{
-        rune_validation::rune_etching_has_valid_commit_with_reconnect,
-        utils::input_rune_balances_from_tx_inputs,
+        rune_validation::rune_etching_has_valid_commit, utils::input_rune_balances_from_tx_inputs,
     },
     models::{
         db_balance_change::DbBalanceChange, db_ledger_entry::DbLedgerEntry,
@@ -85,6 +84,11 @@ impl IndexCache {
             bitcoin_client,
             bitcoin_client_config: config.bitcoind.clone(),
         }
+    }
+
+    /// Recreate and replace the internal Bitcoin RPC client
+    pub fn reconnect_bitcoin_client(&mut self, ctx: &Context) {
+        self.bitcoin_client = bitcoind_get_client(&self.bitcoin_client_config, ctx);
     }
 
     pub async fn reset_max_rune_number(&mut self, db_tx: &mut Transaction<'_>) {
@@ -177,7 +181,7 @@ impl IndexCache {
         etchings_counter: &mut u64,
         bitcoin_tx: &bitcoin::Transaction,
         inputs_counter: &mut u64,
-    ) {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // Determine rune and validation path via explicit match for clarity
         let provided_rune = etching.rune;
         let rune = provided_rune.unwrap_or_else(|| {
@@ -191,7 +195,7 @@ impl IndexCache {
             // Explicitly reserved names are rejected
             Some(r) if r.is_reserved() => {
                 try_debug!(ctx, "Skipping etching with explicitly reserved rune {}", r);
-                return;
+                return Ok(());
             }
             // Explicit non-reserved names require commit validation
             Some(_) => {
@@ -202,17 +206,15 @@ impl IndexCache {
                     self.tx_cache.location.block_height
                 );
 
-                let is_valid_commitment = rune_etching_has_valid_commit_with_reconnect(
+                let is_valid_commitment = rune_etching_has_valid_commit(
                     &mut self.bitcoin_client,
-                    &self.bitcoin_client_config,
                     ctx,
                     bitcoin_tx,
                     &rune,
                     self.tx_cache.location.block_height as u32,
                     inputs_counter,
                 )
-                .await
-                .unwrap_or(false);
+                .await?;
 
                 try_debug!(
                     ctx,
@@ -223,7 +225,7 @@ impl IndexCache {
 
                 if !is_valid_commitment {
                     try_debug!(ctx, "Invalid rune commitment for etching {}", rune);
-                    return; // Skip invalid etchings
+                    return Ok(()); // Skip invalid etchings
                 }
             }
             // Omitted name (reserved allocation) → skip commitment validation
@@ -251,6 +253,7 @@ impl IndexCache {
         self.add_ledger_entries_to_db_cache(&vec![entry]);
         self.next_rune_number += 1;
         *etchings_counter += 1;
+        Ok(())
     }
 
     pub async fn apply_cenotaph_etching(

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -178,8 +178,6 @@ impl IndexCache {
         bitcoin_tx: &bitcoin::Transaction,
         inputs_counter: &mut u64,
     ) {
-        let (rune_id, db_rune, entry) = self.tx_cache.apply_etching(etching, self.next_rune_number);
-
         // Determine rune and validation path via explicit match for clarity
         let provided_rune = etching.rune;
         let rune = provided_rune.unwrap_or_else(|| {
@@ -237,6 +235,9 @@ impl IndexCache {
                 );
             }
         }
+
+        // Only mutate cache and collect DB rows after validation succeeds or is skipped
+        let (rune_id, db_rune, entry) = self.tx_cache.apply_etching(etching, self.next_rune_number);
 
         try_debug!(
             ctx,

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -207,7 +207,7 @@ impl IndexCache {
                 );
 
                 let is_valid_commitment = rune_etching_has_valid_commit(
-                    &mut self.bitcoin_client,
+                    &self.bitcoin_client,
                     ctx,
                     bitcoin_tx,
                     &rune,

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -1,8 +1,13 @@
 use std::{collections::HashMap, num::NonZeroUsize, str::FromStr};
 
 use bitcoin::{Network, ScriptBuf};
-use bitcoind::{try_debug, try_warn, types::bitcoin::TxIn, utils::Context};
-use config::Config;
+use bitcoind::{
+    bitcoincore_rpc::Client as BitcoinRPCClient,
+    try_debug, try_warn,
+    types::bitcoin::TxIn,
+    utils::{bitcoind::bitcoind_get_client, Context},
+};
+use config::{BitcoindConfig, Config};
 use deadpool_postgres::{Pool, Transaction};
 use lru::LruCache;
 use ordinals_parser::{Cenotaph, Edict, Etching, Rune, RuneId, Runestone};
@@ -13,7 +18,10 @@ use super::{
     transaction_location::TransactionLocation, utils::move_block_output_cache_to_output_cache,
 };
 use crate::db::{
-    cache::utils::input_rune_balances_from_tx_inputs,
+    cache::{
+        rune_validation::rune_etching_has_valid_commit_with_reconnect,
+        utils::input_rune_balances_from_tx_inputs,
+    },
     models::{
         db_balance_change::DbBalanceChange, db_ledger_entry::DbLedgerEntry,
         db_ledger_operation::DbLedgerOperation, db_rune::DbRune, db_supply_change::DbSupplyChange,
@@ -40,13 +48,18 @@ pub struct IndexCache {
     tx_cache: TransactionCache,
     /// Keeps rows that have not yet been inserted in the DB.
     pub db_cache: DbCache,
+    /// Bitcoin RPC client used to validate rune commitments.
+    pub bitcoin_client: BitcoinRPCClient,
+    /// Bitcoin RPC client configuration.
+    bitcoin_client_config: BitcoindConfig,
 }
 
 impl IndexCache {
-    pub async fn new(config: &Config, pg_pool: &Pool) -> Self {
+    pub async fn new(config: &Config, pg_pool: &Pool, ctx: &Context) -> Self {
         let pg_client = pg_pool_client(pg_pool).await.unwrap();
         let network = config.bitcoind.network;
         let cap = NonZeroUsize::new(config.runes.as_ref().unwrap().lru_cache_size).unwrap();
+        let bitcoin_client = bitcoind_get_client(&config.bitcoind, ctx);
         IndexCache {
             network,
             next_rune_number: pg_get_max_rune_number(&pg_client).await + 1,
@@ -69,6 +82,8 @@ impl IndexCache {
                 0,
             ),
             db_cache: DbCache::new(),
+            bitcoin_client,
+            bitcoin_client_config: config.bitcoind.clone(),
         }
     }
 
@@ -160,8 +175,50 @@ impl IndexCache {
         _db_tx: &mut Transaction<'_>,
         ctx: &Context,
         etchings_counter: &mut u64,
+        bitcoin_tx: &bitcoin::Transaction,
+        inputs_counter: &mut u64,
     ) {
         let (rune_id, db_rune, entry) = self.tx_cache.apply_etching(etching, self.next_rune_number);
+
+        // Get the rune from the etching
+        let rune = etching.rune.unwrap_or_else(|| {
+            // If no rune name is provided, generate the rune's reserved name
+            Rune::reserved(
+                self.tx_cache.location.block_height,
+                self.tx_cache.location.tx_index,
+            )
+        });
+
+        // Only check if rune name is reserved when a rune name is explicitly provided
+        if let Some(provided_rune) = etching.rune {
+            if provided_rune.is_reserved() {
+                try_debug!(
+                    ctx,
+                    "Invalid rune for etching, reserved rune {}",
+                    provided_rune
+                );
+                return;
+            }
+        }
+
+        // Validate rune commitment
+        let is_valid_commitment = rune_etching_has_valid_commit_with_reconnect(
+            &mut self.bitcoin_client,
+            &self.bitcoin_client_config,
+            ctx,
+            bitcoin_tx,
+            &rune,
+            self.tx_cache.location.block_height as u32,
+            inputs_counter,
+        )
+        .await
+        .unwrap_or(false);
+
+        if !is_valid_commitment {
+            try_debug!(ctx, "Invalid rune commitment for etching {}", rune);
+            return; // Skip invalid etchings
+        }
+
         try_debug!(
             ctx,
             "Etching {spaced_name} ({id}) {location}",

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -10,7 +10,7 @@ use bitcoind::{
 use config::{BitcoindConfig, Config};
 use deadpool_postgres::{Pool, Transaction};
 use lru::LruCache;
-use ordinals_parser::{Cenotaph, Edict, Etching, Rune, RuneId, Runestone};
+use ordinals_parser::{Cenotaph, Edict, Etching, Height, Rune, RuneId, Runestone};
 use postgres::pg_pool_client;
 
 use super::{
@@ -51,6 +51,8 @@ pub struct IndexCache {
     pub bitcoin_client: BitcoinRpcClient,
     /// Bitcoin RPC client configuration.
     bitcoin_client_config: BitcoindConfig,
+    /// Current minimum unlocked rune name threshold for explicit names.
+    minimum_rune: Rune,
 }
 
 impl IndexCache {
@@ -83,6 +85,7 @@ impl IndexCache {
             db_cache: DbCache::new(),
             bitcoin_client,
             bitcoin_client_config: config.bitcoind.clone(),
+            minimum_rune: Rune(0),
         }
     }
 
@@ -106,6 +109,10 @@ impl IndexCache {
         db_tx: &mut Transaction<'_>,
         ctx: &Context,
     ) {
+        // Update the dynamic minimum name threshold based on current block height.
+        self.minimum_rune =
+            Rune::minimum_at_height(self.network, Height(location.block_height as u32));
+
         let input_runes = input_rune_balances_from_tx_inputs(
             tx_inputs,
             &self.block_output_cache,
@@ -189,6 +196,17 @@ impl IndexCache {
                     ctx,
                     "Skipping etching with explicitly reserved rune {}",
                     rune
+                );
+                return Ok(());
+            }
+            // Reject explicit names that are below the currently unlocked minimum.
+            Some(rune) if rune < self.minimum_rune => {
+                try_debug!(
+                    ctx,
+                    "Skipping etching with name {} below minimum {} at {}",
+                    rune,
+                    self.minimum_rune,
+                    self.tx_cache.location.to_string()
                 );
                 return Ok(());
             }
@@ -501,5 +519,132 @@ impl IndexCache {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{absolute::LockTime, transaction::Version, Transaction};
+    use bitcoind::utils::Context;
+    use config::{Config, PgDatabaseConfig};
+    use ordinals_parser::Rune;
+    use postgres::{pg_begin, pg_pool, pg_pool_client};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn apply_etching_skips_with_early_returns() {
+        // Minimal IndexCache without hitting DB in constructor
+        let ctx = Context::empty();
+        let network = bitcoin::Network::Bitcoin;
+        let cap = std::num::NonZeroUsize::new(1).unwrap();
+        let mut index = IndexCache {
+            network,
+            next_rune_number: 1,
+            rune_cache: lru::LruCache::new(cap),
+            rune_total_mints_cache: lru::LruCache::new(cap),
+            output_cache: lru::LruCache::new(cap),
+            block_output_cache: HashMap::new(),
+            tx_cache: TransactionCache::new(
+                TransactionLocation {
+                    network,
+                    block_hash: "".to_string(),
+                    block_height: 840_000,
+                    timestamp: 0,
+                    tx_index: 0,
+                    tx_id: "".to_string(),
+                },
+                HashMap::new(),
+                HashMap::new(),
+                None,
+                0,
+            ),
+            db_cache: DbCache::new(),
+            bitcoin_client: bitcoind::utils::bitcoind::bitcoind_get_client(
+                &Config::test_default().bitcoind,
+                &ctx,
+            ),
+            bitcoin_client_config: Config::test_default().bitcoind,
+            minimum_rune: Rune::minimum_at_height(network, Height(840_000)),
+        };
+
+        let start_n = index.next_rune_number;
+
+        // Deadpool transaction to satisfy signature (won't be used due to early returns)
+        let pool = pg_pool(&PgDatabaseConfig {
+            dbname: "postgres".to_string(),
+            host: "localhost".to_string(),
+            port: 5432,
+            user: "postgres".to_string(),
+            password: Some("postgres".to_string()),
+            search_path: None,
+            pool_max_size: Some(1),
+        })
+        .expect("pool");
+        let mut client = pg_pool_client(&pool).await.expect("client");
+        let mut db_tx = pg_begin(&mut client).await.expect("tx");
+
+        // Create an empty tx
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![],
+        };
+        let mut inputs_counter = 0;
+
+        // Reserved explicit name
+        let etching_reserved = Etching {
+            rune: Some(Rune::reserved(840_000, 0)),
+            ..Default::default()
+        };
+        let res_reserved = index
+            .apply_etching(
+                &etching_reserved,
+                &mut db_tx,
+                &ctx,
+                &mut 0u64,
+                &tx,
+                &mut inputs_counter,
+            )
+            .await;
+        assert!(res_reserved.is_ok());
+        assert_eq!(index.next_rune_number, start_n);
+
+        // Lexicographically above max name
+        let etching_above_max = Etching {
+            rune: Some("DOGDOGDOGDOGDOGDOGDOGDOG".parse().unwrap()),
+            ..Default::default()
+        };
+        let res_above = index
+            .apply_etching(
+                &etching_above_max,
+                &mut db_tx,
+                &ctx,
+                &mut 0u64,
+                &tx,
+                &mut inputs_counter,
+            )
+            .await;
+        assert!(res_above.is_ok());
+        assert_eq!(index.next_rune_number, start_n);
+
+        // Below minimum should also be skipped; choose a small rune 'A'
+        let etching_below_min = Etching {
+            rune: Some("A".parse().unwrap()),
+            ..Default::default()
+        };
+        let res_below = index
+            .apply_etching(
+                &etching_below_min,
+                &mut db_tx,
+                &ctx,
+                &mut 0u64,
+                &tx,
+                &mut inputs_counter,
+            )
+            .await;
+        assert!(res_below.is_ok());
+        assert_eq!(index.next_rune_number, start_n);
     }
 }

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, num::NonZeroUsize, str::FromStr};
 use bitcoin::{Network, ScriptBuf};
 use bitcoind::{
     bitcoincore_rpc::Client as BitcoinRpcClient,
-    try_debug, try_warn,
+    try_debug, try_error, try_warn,
     types::bitcoin::TxIn,
     utils::{bitcoind::bitcoind_get_client, Context},
 };
@@ -181,32 +181,20 @@ impl IndexCache {
         etchings_counter: &mut u64,
         bitcoin_tx: &bitcoin::Transaction,
         inputs_counter: &mut u64,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Determine rune and validation path via explicit match for clarity
-        let provided_rune = etching.rune;
-        let rune = provided_rune.unwrap_or_else(|| {
-            Rune::reserved(
-                self.tx_cache.location.block_height,
-                self.tx_cache.location.tx_index,
-            )
-        });
-
-        match provided_rune {
+    ) -> Result<(), String> {
+        match etching.rune {
             // Explicitly reserved names are rejected
-            Some(r) if r.is_reserved() => {
-                try_debug!(ctx, "Skipping etching with explicitly reserved rune {}", r);
+            Some(rune) if rune.is_reserved() => {
+                try_debug!(
+                    ctx,
+                    "Skipping etching with explicitly reserved rune {}",
+                    rune
+                );
                 return Ok(());
             }
             // Explicit non-reserved names require commit validation
-            Some(_) => {
-                try_debug!(
-                    ctx,
-                    "Attempting to validate rune commitment for non-reserved rune {} at block height {}",
-                    rune,
-                    self.tx_cache.location.block_height
-                );
-
-                let is_valid_commitment = rune_etching_has_valid_commit(
+            Some(rune) => {
+                if !rune_etching_has_valid_commit(
                     &self.bitcoin_client,
                     ctx,
                     bitcoin_tx,
@@ -214,31 +202,15 @@ impl IndexCache {
                     self.tx_cache.location.block_height as u32,
                     inputs_counter,
                 )
-                .await?;
-
-                try_debug!(
-                    ctx,
-                    "Rune commitment validation result for {}: {}",
-                    rune,
-                    is_valid_commitment
-                );
-
-                if !is_valid_commitment {
-                    try_debug!(ctx, "Invalid rune commitment for etching {}", rune);
-                    return Ok(()); // Skip invalid etchings
+                .await?
+                {
+                    try_error!(ctx, "Invalid rune commitment for etching {rune}");
+                    return Ok(());
                 }
             }
-            // Omitted name (reserved allocation) → skip commitment validation
-            None => {
-                try_debug!(
-                    ctx,
-                    "Skipping commitment validation for rune {} (reserved allocation)",
-                    rune
-                );
-            }
+            None => {}
         }
 
-        // Only mutate cache and collect DB rows after validation succeeds or is skipped
         let (rune_id, db_rune, entry) = self.tx_cache.apply_etching(etching, self.next_rune_number);
 
         try_debug!(

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -252,7 +252,46 @@ impl IndexCache {
         _db_tx: &mut Transaction<'_>,
         ctx: &Context,
         cenotaph_etchings_counter: &mut u64,
-    ) {
+        bitcoin_tx: &bitcoin::Transaction,
+        inputs_counter: &mut u64,
+    ) -> Result<(), String> {
+        // Explicitly reserved names are rejected
+        if rune.is_reserved() {
+            try_debug!(
+                ctx,
+                "Skipping cenotaph etching with explicitly reserved rune {}",
+                rune
+            );
+            return Ok(());
+        }
+
+        // Reject names that are below the currently unlocked minimum
+        if *rune < self.minimum_rune {
+            try_debug!(
+                ctx,
+                "Skipping cenotaph etching with name {} below minimum {} at {}",
+                rune,
+                self.minimum_rune,
+                self.tx_cache.location.to_string()
+            );
+            return Ok(());
+        }
+
+        // Validate commit for cenotaph etchings as well
+        if !rune_etching_has_valid_commit(
+            &self.bitcoin_client,
+            ctx,
+            bitcoin_tx,
+            rune,
+            self.tx_cache.location.block_height as u32,
+            inputs_counter,
+        )
+        .await?
+        {
+            try_error!(ctx, "Invalid rune commitment for cenotaph etching {rune}");
+            return Ok(());
+        }
+
         let (rune_id, db_rune, entry) = self
             .tx_cache
             .apply_cenotaph_etching(rune, self.next_rune_number);
@@ -268,6 +307,7 @@ impl IndexCache {
         self.add_ledger_entries_to_db_cache(&vec![entry]);
         self.next_rune_number += 1;
         *cenotaph_etchings_counter += 1;
+        Ok(())
     }
 
     pub async fn apply_mint(

--- a/components/runes/src/db/cache/index_cache.rs
+++ b/components/runes/src/db/cache/index_cache.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, num::NonZeroUsize, str::FromStr};
 
 use bitcoin::{Network, ScriptBuf};
 use bitcoind::{
-    bitcoincore_rpc::Client as BitcoinRPCClient,
+    bitcoincore_rpc::Client as BitcoinRpcClient,
     try_debug, try_warn,
     types::bitcoin::TxIn,
     utils::{bitcoind::bitcoind_get_client, Context},
@@ -49,7 +49,7 @@ pub struct IndexCache {
     /// Keeps rows that have not yet been inserted in the DB.
     pub db_cache: DbCache,
     /// Bitcoin RPC client used to validate rune commitments.
-    pub bitcoin_client: BitcoinRPCClient,
+    pub bitcoin_client: BitcoinRpcClient,
     /// Bitcoin RPC client configuration.
     bitcoin_client_config: BitcoindConfig,
 }
@@ -180,43 +180,62 @@ impl IndexCache {
     ) {
         let (rune_id, db_rune, entry) = self.tx_cache.apply_etching(etching, self.next_rune_number);
 
-        // Get the rune from the etching
-        let rune = etching.rune.unwrap_or_else(|| {
-            // If no rune name is provided, generate the rune's reserved name
+        // Determine rune and validation path via explicit match for clarity
+        let provided_rune = etching.rune;
+        let rune = provided_rune.unwrap_or_else(|| {
             Rune::reserved(
                 self.tx_cache.location.block_height,
                 self.tx_cache.location.tx_index,
             )
         });
 
-        // Only check if rune name is reserved when a rune name is explicitly provided
-        if let Some(provided_rune) = etching.rune {
-            if provided_rune.is_reserved() {
-                try_debug!(
-                    ctx,
-                    "Invalid rune for etching, reserved rune {}",
-                    provided_rune
-                );
+        match provided_rune {
+            // Explicitly reserved names are rejected
+            Some(r) if r.is_reserved() => {
+                try_debug!(ctx, "Skipping etching with explicitly reserved rune {}", r);
                 return;
             }
-        }
+            // Explicit non-reserved names require commit validation
+            Some(_) => {
+                try_debug!(
+                    ctx,
+                    "Attempting to validate rune commitment for non-reserved rune {} at block height {}",
+                    rune,
+                    self.tx_cache.location.block_height
+                );
 
-        // Validate rune commitment
-        let is_valid_commitment = rune_etching_has_valid_commit_with_reconnect(
-            &mut self.bitcoin_client,
-            &self.bitcoin_client_config,
-            ctx,
-            bitcoin_tx,
-            &rune,
-            self.tx_cache.location.block_height as u32,
-            inputs_counter,
-        )
-        .await
-        .unwrap_or(false);
+                let is_valid_commitment = rune_etching_has_valid_commit_with_reconnect(
+                    &mut self.bitcoin_client,
+                    &self.bitcoin_client_config,
+                    ctx,
+                    bitcoin_tx,
+                    &rune,
+                    self.tx_cache.location.block_height as u32,
+                    inputs_counter,
+                )
+                .await
+                .unwrap_or(false);
 
-        if !is_valid_commitment {
-            try_debug!(ctx, "Invalid rune commitment for etching {}", rune);
-            return; // Skip invalid etchings
+                try_debug!(
+                    ctx,
+                    "Rune commitment validation result for {}: {}",
+                    rune,
+                    is_valid_commitment
+                );
+
+                if !is_valid_commitment {
+                    try_debug!(ctx, "Invalid rune commitment for etching {}", rune);
+                    return; // Skip invalid etchings
+                }
+            }
+            // Omitted name (reserved allocation) → skip commitment validation
+            None => {
+                try_debug!(
+                    ctx,
+                    "Skipping commitment validation for rune {} (reserved allocation)",
+                    rune
+                );
+            }
         }
 
         try_debug!(

--- a/components/runes/src/db/cache/mod.rs
+++ b/components/runes/src/db/cache/mod.rs
@@ -1,6 +1,7 @@
 pub mod db_cache;
 pub mod index_cache;
 pub mod input_rune_balance;
+pub mod rune_validation;
 pub mod transaction_cache;
 pub mod transaction_location;
 pub mod utils;

--- a/components/runes/src/db/cache/rune_validation.rs
+++ b/components/runes/src/db/cache/rune_validation.rs
@@ -1,0 +1,686 @@
+use std::str::FromStr;
+
+use bitcoin::{Script, Transaction, Witness};
+use bitcoind::{
+    bitcoincore_rpc::{self, Client as BitcoinRPCClient},
+    try_info, try_warn,
+    utils::{
+        bitcoind::{bitcoin_get_raw_transaction, bitcoind_get_block_height, bitcoind_get_client},
+        Context,
+    },
+};
+use config::BitcoindConfig;
+use ordinals_parser::{Rune, Runestone};
+
+fn unversioned_leaf_script_from_witness(witness: &Witness) -> Option<&Script> {
+    #[allow(deprecated)]
+    witness.tapscript()
+}
+
+/// Reserved runes cannot be etched because they serve as a fallback mechanism for failed etchings
+/// and prevent namespace collision in the Bitcoin Runes protocol. When an etching transaction fails
+/// to specify a valid rune name or the etching is malformed, the protocol automatically assigns a
+/// "reserved" rune name using a deterministic formula to maintain protocol integrity.
+pub fn is_reserved(rune: &Rune) -> bool {
+    rune.0 >= Rune::RESERVED
+}
+
+/// Validates that a rune etching transaction has a proper commitment transaction.
+///
+/// The Bitcoin Runes protocol requires a two-step "commit-reveal" process for etching new runes:
+/// 1. **Commit**: A transaction includes the rune's commitment bytes in a tapscript
+/// 2. **Reveal**: A subsequent transaction (this one) actually performs the etching
+///
+/// This function validates the reveal transaction by checking that:
+/// - At least one input spends from a taproot output that contains the rune's commitment
+/// - The commitment transaction was confirmed at least 6 blocks before the reveal
+/// - The commitment appears in a valid tapscript witness
+///
+/// # Arguments
+/// * `config` - Bitcoin node configuration for RPC calls
+/// * `ctx` - Logging and error context
+/// * `tx` - The reveal transaction attempting to etch the rune
+/// * `rune` - The rune being etched (used to generate expected commitment bytes)
+/// * `reveal_block_height` - Block height where this reveal transaction appears
+/// * `inputs_counter` - Mutable counter tracking total inputs processed (for metrics)
+///
+/// # Returns
+/// * `Ok(true)` - Valid commitment found with sufficient confirmations
+/// * `Ok(false)` - No valid commitment found or insufficient confirmations
+/// * `Err(_)` - Error accessing blockchain data or parsing scripts
+///
+/// # Validation Rules
+/// - Commitment must appear in tapscript witness data
+/// - The spent output must be a P2TR (taproot) output
+/// - At least 6 block confirmations between commit and reveal
+/// - Commitment bytes must exactly match `rune.commitment()`
+async fn rune_etching_has_valid_commit(
+    bitcoin_client: &BitcoinRPCClient,
+    ctx: &Context,
+    tx: &Transaction,
+    rune: &Rune,
+    reveal_block_height: u32,
+    inputs_counter: &mut u64,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    let commitment = rune.commitment();
+
+    // Check each input for valid commitment (the commitment could be in any input)
+    for input in &tx.input {
+        *inputs_counter += 1;
+        // Extract tapscript from witness data (note: this doesn't guarantee the spent output is taproot)
+        let Some(tapscript) = unversioned_leaf_script_from_witness(&input.witness) else {
+            continue;
+        };
+
+        for instruction in tapscript.instructions() {
+            // Skip invalid script instructions
+            let Ok(instruction) = instruction else {
+                break;
+            };
+
+            let Some(pushbytes) = instruction.push_bytes() else {
+                continue;
+            };
+
+            // Check if this instruction pushes the expected commitment bytes
+            if pushbytes.as_bytes() != commitment {
+                continue;
+            }
+
+            let txid =
+                bitcoincore_rpc::bitcoin::Txid::from_str(&input.previous_output.txid.to_string())
+                    .unwrap();
+
+            // Fetch the commit transaction to validate taproot output and get block height
+            let Some(commit_tx_info) = bitcoin_get_raw_transaction(bitcoin_client, ctx, &txid)
+            else {
+                panic!(
+                    "can't get input transaction: {}",
+                    input.previous_output.txid
+                );
+            };
+
+            // Verify the spent output is a taproot (P2TR) output
+            let taproot = commit_tx_info.vout[input.previous_output.vout as usize]
+                .script_pub_key
+                .script()?
+                .is_p2tr();
+
+            if !taproot {
+                continue;
+            }
+
+            // Get commit transaction's block height to check confirmation count
+            let commit_tx_height =
+                bitcoind_get_block_height(bitcoin_client, ctx, &commit_tx_info.blockhash.unwrap());
+
+            // Calculate confirmations and check minimum requirement (6 blocks)
+            let confirmations = reveal_block_height.checked_sub(commit_tx_height).unwrap() + 1;
+            if confirmations >= u32::from(Runestone::COMMIT_CONFIRMATIONS) {
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+/// Validates that a rune etching transaction has a proper commitment transaction with automatic reconnection.
+///
+/// This function wraps the core validation logic with connection error handling. If a connection
+/// error is detected, it will attempt to reconnect the Bitcoin RPC client and retry the validation.
+pub async fn rune_etching_has_valid_commit_with_reconnect(
+    bitcoin_client: &mut BitcoinRPCClient,
+    config: &BitcoindConfig,
+    ctx: &Context,
+    tx: &Transaction,
+    rune: &Rune,
+    reveal_block_height: u32,
+    inputs_counter: &mut u64,
+) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+    match rune_etching_has_valid_commit(
+        bitcoin_client,
+        ctx,
+        tx,
+        rune,
+        reveal_block_height,
+        inputs_counter,
+    )
+    .await
+    {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            // Check if this is a connection error
+            if is_connection_error(&error) {
+                try_warn!(ctx, "Bitcoin RPC connection error detected: {}", error);
+                try_info!(ctx, "Attempting to reconnect Bitcoin RPC client...");
+
+                // Create a new client connection
+                *bitcoin_client = bitcoind_get_client(config, ctx);
+                try_info!(
+                    ctx,
+                    "Bitcoin RPC client reconnected, retrying validation..."
+                );
+
+                // Retry the validation with the new connection
+                rune_etching_has_valid_commit(
+                    bitcoin_client,
+                    ctx,
+                    tx,
+                    rune,
+                    reveal_block_height,
+                    inputs_counter,
+                )
+                .await
+            } else {
+                // Not a connection error, propagate the original error
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Checks if an error indicates a connection issue that requires reconnection
+#[allow(clippy::borrowed_box)]
+fn is_connection_error(error: &Box<dyn std::error::Error + Send + Sync>) -> bool {
+    let error_msg = error.to_string().to_lowercase();
+
+    // Check for common connection-related error patterns
+    error_msg.contains("connection refused") ||
+    error_msg.contains("connection reset") ||
+    error_msg.contains("connection closed") ||
+    error_msg.contains("connection timeout") ||
+    error_msg.contains("connection aborted") ||
+    error_msg.contains("broken pipe") ||
+    error_msg.contains("network unreachable") ||
+    error_msg.contains("host unreachable") ||
+    error_msg.contains("timed out") ||
+    error_msg.contains("could not connect") ||
+    error_msg.contains("transport error") ||
+    error_msg.contains("rpc_client_not_connected") ||
+    error_msg.contains("no connection available") ||
+    error_msg.contains("io error") ||
+    error_msg.contains("transport is disconnected") ||
+    // Bitcoin Core specific RPC errors
+    error_msg.contains("rpc_client_not_connected") ||
+    error_msg.contains("work queue depth exceeded")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use bitcoin::{
+        opcodes, script::Builder, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    };
+    use bitcoind::utils::{bitcoind::bitcoind_get_client, Context};
+    use config::BitcoindConfig;
+    use ordinals_parser::Rune;
+
+    use super::*;
+
+    // Mock implementations for testing
+    struct MockBitcoindConfig;
+
+    impl MockBitcoindConfig {
+        fn new() -> BitcoindConfig {
+            BitcoindConfig {
+                rpc_username: "test".to_string(),
+                rpc_password: "test".to_string(),
+                rpc_url: "http://localhost:8332".to_string(),
+                network: bitcoin::Network::Regtest,
+                zmq_url: "tcp://localhost:28332".to_string(),
+            }
+        }
+    }
+
+    fn create_mock_transaction_with_witness(witness_data: Vec<Vec<u8>>) -> Transaction {
+        let mut witness = Witness::new();
+        for data in witness_data {
+            witness.push(data);
+        }
+
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: bitcoin::Txid::from_str(
+                        "0000000000000000000000000000000000000000000000000000000000000001",
+                    )
+                    .unwrap(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness,
+            }],
+            output: vec![TxOut {
+                value: bitcoin::Amount::from_sat(1000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    fn create_mock_transaction_no_witness() -> Transaction {
+        Transaction {
+            version: bitcoin::transaction::Version::TWO,
+            lock_time: bitcoin::absolute::LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: bitcoin::Txid::from_str(
+                        "0000000000000000000000000000000000000000000000000000000000000001",
+                    )
+                    .unwrap(),
+                    vout: 0,
+                },
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: bitcoin::Amount::from_sat(1000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        }
+    }
+
+    fn create_tapscript_with_commitment(commitment: &[u8]) -> ScriptBuf {
+        use bitcoin::script::PushBytesBuf;
+
+        let push_bytes = PushBytesBuf::try_from(commitment.to_vec()).unwrap();
+        Builder::new()
+            .push_slice(&push_bytes)
+            .push_opcode(opcodes::all::OP_DROP)
+            .push_opcode(opcodes::OP_TRUE)
+            .into_script()
+    }
+
+    /// Tests that reserved runes are correctly identified
+    /// This validates the core reserved rune detection logic
+    #[test]
+    fn test_is_reserved_returns_true_for_reserved_rune() {
+        let reserved_rune = Rune::reserved(840000, 1);
+        // Additional reserved runes for testing
+        let reserved_rune2 = Rune(6402364363415443603228541259936211926);
+        let reserved_rune3 = Rune(6402364363415443603228541259936211927);
+        assert!(is_reserved(&reserved_rune));
+        assert!(is_reserved(&reserved_rune2));
+        assert!(is_reserved(&reserved_rune3));
+    }
+
+    /// Tests that non-reserved runes are not incorrectly flagged as reserved
+    /// This ensures the RESERVED threshold is working correctly
+    #[test]
+    fn test_is_reserved_returns_false_for_non_reserved_rune() {
+        let non_reserved_rune = Rune(1000); // Well below RESERVED threshold
+        assert!(!is_reserved(&non_reserved_rune));
+    }
+
+    /// Tests that transactions without witness data fail commitment validation
+    /// This validates: "tx input is not a commit" case
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_fails_with_no_witness() {
+        let config = MockBitcoindConfig::new();
+        let ctx = Context::empty();
+        let mut bitcoin_client = bitcoind_get_client(&config, &ctx);
+        let tx = create_mock_transaction_no_witness();
+        let rune = Rune(1000);
+        let mut inputs_counter = 0;
+
+        let result = rune_etching_has_valid_commit(
+            &mut bitcoin_client,
+            &ctx,
+            &tx,
+            &rune,
+            840005,
+            &mut inputs_counter,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result);
+        assert_eq!(inputs_counter, 1);
+    }
+
+    /// Tests that transactions with incorrect commitment data fail validation
+    /// This validates the commitment matching logic
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_fails_with_wrong_commitment() {
+        let config = MockBitcoindConfig::new();
+        let ctx = Context::empty();
+        let mut bitcoin_client = bitcoind_get_client(&config, &ctx);
+        let rune = Rune(1000);
+        let wrong_commitment = b"wrong_commitment_data";
+
+        // Create tapscript with wrong commitment
+        let tapscript = create_tapscript_with_commitment(wrong_commitment);
+
+        // Create witness with the tapscript
+        let witness_data = vec![
+            vec![], // Signature placeholder
+            tapscript.to_bytes(),
+        ];
+
+        let tx = create_mock_transaction_with_witness(witness_data);
+        let mut inputs_counter = 0;
+
+        let result = rune_etching_has_valid_commit(
+            &mut bitcoin_client,
+            &ctx,
+            &tx,
+            &rune,
+            840005,
+            &mut inputs_counter,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result);
+        assert_eq!(inputs_counter, 1);
+    }
+
+    /// Tests that rune commitment generation is deterministic and correct
+    /// This validates the core commitment encoding (rune value as bytes, not a hash!)
+    #[test]
+    fn test_rune_commitment_generation() {
+        let rune = Rune(1000);
+        let commitment = rune.commitment();
+
+        // The commitment is the rune value encoded as bytes (little-endian)
+        // For Rune(1000), this is [232, 3] (little-endian encoding of 1000)
+        // 1000 = 0x03E8 -> little-endian [0xE8, 0x03] = [232, 3]
+        assert_eq!(commitment.len(), 2);
+        assert_eq!(commitment, &[232, 3]);
+
+        // Same rune should generate same commitment
+        let rune2 = Rune(1000);
+        let commitment2 = rune2.commitment();
+        assert_eq!(commitment, commitment2);
+
+        // Different rune should generate different commitment
+        let rune3 = Rune(2000);
+        let commitment3 = rune3.commitment();
+        assert_ne!(commitment, commitment3);
+        // Rune(2000) = 0x07D0 -> little-endian [0xD0, 0x07] = [208, 7]
+        assert_eq!(commitment3, &[208, 7]);
+
+        // Test larger rune value that requires more bytes
+        let large_rune = Rune(0x123456789ABCDEF0);
+        let large_commitment = large_rune.commitment();
+        assert!(large_commitment.len() > 2); // Larger values need more bytes
+
+        // Test very small rune (single byte)
+        let small_rune = Rune(42);
+        let small_commitment = small_rune.commitment();
+        assert_eq!(small_commitment, &[42]); // Should be just [42]
+    }
+
+    // Helper function for testing - mimics tx_commits_to_rune but with mockable RPC calls
+    async fn tx_commits_to_rune_with_mocks(
+        tx: &Transaction,
+        rune: &Rune,
+        reveal_block_height: u32,
+        mock_commit_tx_block_height: u32,
+        mock_is_taproot: bool,
+    ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+        let commitment = rune.commitment();
+
+        for input in &tx.input {
+            let Some(tapscript) = unversioned_leaf_script_from_witness(&input.witness) else {
+                continue;
+            };
+
+            for instruction in tapscript.instructions() {
+                let Ok(instruction) = instruction else {
+                    break;
+                };
+
+                let Some(pushbytes) = instruction.push_bytes() else {
+                    continue;
+                };
+
+                if pushbytes.as_bytes() != commitment {
+                    continue;
+                }
+
+                // Mock: Assume we found the commit transaction
+                // In real code: bitcoin_get_raw_transaction(config, ctx, &txid)
+                if !mock_is_taproot {
+                    continue;
+                }
+
+                // Mock: Return our mock block height
+                // In real code: bitcoind_get_block_height(config, ctx, &commit_tx_info.blockhash.unwrap())
+                let commit_tx_height = mock_commit_tx_block_height;
+
+                let confirmations = reveal_block_height.checked_sub(commit_tx_height).unwrap() + 1;
+                if confirmations >= u32::from(Runestone::COMMIT_CONFIRMATIONS) {
+                    return Ok(true);
+                }
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn create_transaction_with_valid_commitment(rune: &Rune) -> Transaction {
+        let commitment = rune.commitment();
+        let tapscript = create_tapscript_with_commitment(&commitment);
+
+        // For taproot script path spending, we need:
+        // - signature (can be empty for script-only validation)
+        // - script
+        // - control block (minimal for testing)
+        let witness_data = vec![
+            vec![], // Empty signature for script-only validation
+            tapscript.to_bytes(),
+            vec![0xc0], // Minimal control block (leaf version + empty merkle path)
+        ];
+
+        create_mock_transaction_with_witness(witness_data)
+    }
+
+    /// Tests that commit_tx in the same block as reveal_tx fails validation
+    /// This validates: "commit_tx (tx_input) happened in same block"
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_fails_same_block() {
+        let rune = Rune(1000);
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840010; // Same block!
+        let is_taproot = true;
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        // Should fail because commit and reveal are in the same block
+        // confirmations = 840010 - 840010 + 1 = 1, which is < 6
+        assert!(!result);
+    }
+
+    /// Tests that commit_tx with insufficient confirmations fails validation
+    /// This validates: "commit_tx has not enough block heights confirmed (6)"
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_fails_insufficient_confirmations() {
+        let rune = Rune(1000);
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840006; // 5 confirmations (840010 - 840006 + 1 = 5)
+        let is_taproot = true;
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        // Should fail because only 5 confirmations, need 6
+        assert!(!result);
+    }
+
+    /// Tests edge case: exactly 5 confirmations should fail
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_fails_exactly_five_confirmations() {
+        let rune = Rune(1000);
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840006; // Exactly 5 confirmations
+        let is_taproot = true;
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        assert!(!result);
+    }
+
+    /// Tests that exactly 6 confirmations should succeed
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_succeeds_exactly_six_confirmations() {
+        let rune = Rune(1000);
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840005; // Exactly 6 confirmations (840010 - 840005 + 1 = 6)
+        let is_taproot = true;
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        // Should succeed with exactly 6 confirmations
+        assert!(result);
+    }
+
+    /// Tests that proper commitment with ≥6 confirmations succeeds
+    /// This validates the happy path of commitment validation
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_succeeds_with_valid_commitment() {
+        let rune = Rune(1000);
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840000; // 11 confirmations (840010 - 840000 + 1 = 11)
+        let is_taproot = true;
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        // Should succeed with sufficient confirmations
+        assert!(result);
+    }
+
+    /// Tests that non-taproot commitment transactions fail
+    /// This validates the taproot requirement
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_fails_non_taproot() {
+        let rune = Rune(1000);
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840000; // Sufficient confirmations
+        let is_taproot = false; // Not a taproot transaction
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        // Should fail because commit tx is not taproot
+        assert!(!result);
+    }
+
+    /// Tests multiple inputs where only one has valid commitment
+    #[tokio::test]
+    async fn test_tx_commits_to_rune_multiple_inputs_one_valid() {
+        let rune = Rune(1000);
+        let commitment = rune.commitment();
+
+        // Create transaction with multiple inputs
+        let mut tx = create_mock_transaction_no_witness();
+
+        // First input: no valid commitment
+        let wrong_tapscript = create_tapscript_with_commitment(b"wrong_commitment");
+        let mut wrong_witness = Witness::new();
+        wrong_witness.push(vec![]); // Empty signature
+        wrong_witness.push(wrong_tapscript.to_bytes());
+        wrong_witness.push(vec![0xc0]); // Control block
+        tx.input[0].witness = wrong_witness;
+
+        // Add second input with valid commitment
+        let valid_tapscript = create_tapscript_with_commitment(&commitment);
+        let mut valid_witness = Witness::new();
+        valid_witness.push(vec![]); // Empty signature
+        valid_witness.push(valid_tapscript.to_bytes());
+        valid_witness.push(vec![0xc0]); // Control block
+
+        tx.input.push(TxIn {
+            previous_output: OutPoint {
+                txid: bitcoin::Txid::from_str(
+                    "0000000000000000000000000000000000000000000000000000000000000002",
+                )
+                .unwrap(),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: valid_witness,
+        });
+
+        let reveal_block_height = 840010;
+        let commit_block_height = 840000;
+        let is_taproot = true;
+
+        let result = tx_commits_to_rune_with_mocks(
+            &tx,
+            &rune,
+            reveal_block_height,
+            commit_block_height,
+            is_taproot,
+        )
+        .await
+        .unwrap();
+
+        // Should succeed because second input has valid commitment
+        assert!(result);
+    }
+}

--- a/components/runes/src/db/cache/rune_validation.rs
+++ b/components/runes/src/db/cache/rune_validation.rs
@@ -15,14 +15,6 @@ fn unversioned_leaf_script_from_witness(witness: &Witness) -> Option<&Script> {
     witness.tapscript()
 }
 
-/// Reserved runes cannot be etched because they serve as a fallback mechanism for failed etchings
-/// and prevent namespace collision in the Bitcoin Runes protocol. When an etching transaction fails
-/// to specify a valid rune name or the etching is malformed, the protocol automatically assigns a
-/// "reserved" rune name using a deterministic formula to maintain protocol integrity.
-pub fn is_reserved(rune: &Rune) -> bool {
-    rune.0 >= Rune::RESERVED
-}
-
 /// Validates that a rune etching transaction has a proper commitment transaction.
 ///
 /// The Bitcoin Runes protocol requires a two-step "commit-reveal" process for etching new runes:
@@ -59,7 +51,7 @@ pub async fn rune_etching_has_valid_commit(
     rune: &Rune,
     reveal_block_height: u32,
     inputs_counter: &mut u64,
-) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<bool, String> {
     let commitment = rune.commitment();
 
     // Check each input for valid commitment (the commitment could be in any input)
@@ -70,38 +62,30 @@ pub async fn rune_etching_has_valid_commit(
             continue;
         };
 
+        // From ord docs: A commitment consists of a data push of the rune name, encoded as a little-endian integer with trailing
+        // zero bytes elided, present in an input witness tapscript where the output being spent has at least six confirmations.
         for instruction in tapscript.instructions() {
-            // Skip invalid script instructions
             let Ok(instruction) = instruction else {
                 break;
             };
-
             let Some(pushbytes) = instruction.push_bytes() else {
                 continue;
             };
-
-            // Check if this instruction pushes the expected commitment bytes
             if pushbytes.as_bytes() != commitment {
                 continue;
             }
 
+            // Fetch the commit transaction to validate taproot output and get block height
             let txid =
                 bitcoincore_rpc::bitcoin::Txid::from_str(&input.previous_output.txid.to_string())
                     .unwrap();
-
-            // Fetch the commit transaction to validate taproot output and get block height
-            let Some(commit_tx_info) = bitcoin_get_raw_transaction(bitcoin_client, ctx, &txid)
-            else {
-                panic!(
-                    "can't get input transaction: {}",
-                    input.previous_output.txid
-                );
-            };
+            let commit_tx_info = bitcoin_get_raw_transaction(bitcoin_client, ctx, &txid)?;
 
             // Verify the spent output is a taproot (P2TR) output
             let taproot = commit_tx_info.vout[input.previous_output.vout as usize]
                 .script_pub_key
-                .script()?
+                .script()
+                .map_err(|e| format!("can't get script: {e}"))?
                 .is_p2tr();
 
             if !taproot {
@@ -121,32 +105,6 @@ pub async fn rune_etching_has_valid_commit(
     }
 
     Ok(false)
-}
-
-/// Checks if an error indicates a connection issue that requires reconnection
-#[allow(clippy::borrowed_box)]
-pub fn is_connection_error(error: &Box<dyn std::error::Error + Send + Sync>) -> bool {
-    let error_msg = error.to_string().to_lowercase();
-
-    // Check for common connection-related error patterns
-    error_msg.contains("connection refused") ||
-    error_msg.contains("connection reset") ||
-    error_msg.contains("connection closed") ||
-    error_msg.contains("connection timeout") ||
-    error_msg.contains("connection aborted") ||
-    error_msg.contains("broken pipe") ||
-    error_msg.contains("network unreachable") ||
-    error_msg.contains("host unreachable") ||
-    error_msg.contains("timed out") ||
-    error_msg.contains("could not connect") ||
-    error_msg.contains("transport error") ||
-    error_msg.contains("rpc_client_not_connected") ||
-    error_msg.contains("no connection available") ||
-    error_msg.contains("io error") ||
-    error_msg.contains("transport is disconnected") ||
-    // Bitcoin Core specific RPC errors
-    error_msg.contains("rpc_client_not_connected") ||
-    error_msg.contains("work queue depth exceeded")
 }
 
 #[cfg(test)]
@@ -248,9 +206,9 @@ mod tests {
         // Additional reserved runes for testing
         let reserved_rune2 = Rune(6402364363415443603228541259936211926);
         let reserved_rune3 = Rune(6402364363415443603228541259936211927);
-        assert!(is_reserved(&reserved_rune));
-        assert!(is_reserved(&reserved_rune2));
-        assert!(is_reserved(&reserved_rune3));
+        assert!(reserved_rune.is_reserved());
+        assert!(reserved_rune2.is_reserved());
+        assert!(reserved_rune3.is_reserved());
     }
 
     /// Tests that non-reserved runes are not incorrectly flagged as reserved
@@ -258,7 +216,7 @@ mod tests {
     #[test]
     fn test_is_reserved_returns_false_for_non_reserved_rune() {
         let non_reserved_rune = Rune(1000); // Well below RESERVED threshold
-        assert!(!is_reserved(&non_reserved_rune));
+        assert!(!non_reserved_rune.is_reserved());
     }
 
     /// Tests that transactions without witness data fail commitment validation
@@ -658,11 +616,11 @@ mod tests {
         // here we check the underlying rule: reserved detection works and commitment bytes
         // are still generated deterministically (not used for validation in reserved path).
         let reserved = Rune::reserved(840000, 0);
-        assert!(super::is_reserved(&reserved));
+        assert!(reserved.is_reserved());
 
         // Named non-reserved like SUPERDOME must not be reserved
         let named = SpacedRune::from_str("SUPERDOME").unwrap().rune;
-        assert!(!super::is_reserved(&named));
+        assert!(!named.is_reserved());
     }
 
     // Helper function to create a mock config for testing

--- a/components/runes/src/db/cache/rune_validation.rs
+++ b/components/runes/src/db/cache/rune_validation.rs
@@ -3,13 +3,11 @@ use std::str::FromStr;
 use bitcoin::{Script, Transaction, Witness};
 use bitcoind::{
     bitcoincore_rpc::{self, Client as BitcoinRPCClient},
-    try_info, try_warn,
     utils::{
-        bitcoind::{bitcoin_get_raw_transaction, bitcoind_get_block_height, bitcoind_get_client},
+        bitcoind::{bitcoin_get_raw_transaction, bitcoind_get_block_height},
         Context,
     },
 };
-use config::BitcoindConfig;
 use ordinals_parser::{Rune, Runestone};
 
 fn unversioned_leaf_script_from_witness(witness: &Witness) -> Option<&Script> {

--- a/components/runes/src/db/cache/rune_validation.rs
+++ b/components/runes/src/db/cache/rune_validation.rs
@@ -54,7 +54,7 @@ pub fn is_reserved(rune: &Rune) -> bool {
 /// - The spent output must be a P2TR (taproot) output
 /// - At least 6 block confirmations between commit and reveal
 /// - Commitment bytes must exactly match `rune.commitment()`
-async fn rune_etching_has_valid_commit(
+pub async fn rune_etching_has_valid_commit(
     bitcoin_client: &BitcoinRPCClient,
     ctx: &Context,
     tx: &Transaction,
@@ -112,7 +112,7 @@ async fn rune_etching_has_valid_commit(
 
             // Get commit transaction's block height to check confirmation count
             let commit_tx_height =
-                bitcoind_get_block_height(bitcoin_client, ctx, &commit_tx_info.blockhash.unwrap());
+                bitcoind_get_block_height(bitcoin_client, ctx, &commit_tx_info.blockhash.unwrap())?;
 
             // Calculate confirmations and check minimum requirement (6 blocks)
             let confirmations = reveal_block_height.checked_sub(commit_tx_height).unwrap() + 1;
@@ -125,64 +125,9 @@ async fn rune_etching_has_valid_commit(
     Ok(false)
 }
 
-/// Validates that a rune etching transaction has a proper commitment transaction with automatic reconnection.
-///
-/// This function wraps the core validation logic with connection error handling. If a connection
-/// error is detected, it will attempt to reconnect the Bitcoin RPC client and retry the validation.
-pub async fn rune_etching_has_valid_commit_with_reconnect(
-    bitcoin_client: &mut BitcoinRPCClient,
-    config: &BitcoindConfig,
-    ctx: &Context,
-    tx: &Transaction,
-    rune: &Rune,
-    reveal_block_height: u32,
-    inputs_counter: &mut u64,
-) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-    match rune_etching_has_valid_commit(
-        bitcoin_client,
-        ctx,
-        tx,
-        rune,
-        reveal_block_height,
-        inputs_counter,
-    )
-    .await
-    {
-        Ok(result) => Ok(result),
-        Err(error) => {
-            // Check if this is a connection error
-            if is_connection_error(&error) {
-                try_warn!(ctx, "Bitcoin RPC connection error detected: {}", error);
-                try_info!(ctx, "Attempting to reconnect Bitcoin RPC client...");
-
-                // Create a new client connection
-                *bitcoin_client = bitcoind_get_client(config, ctx);
-                try_info!(
-                    ctx,
-                    "Bitcoin RPC client reconnected, retrying validation..."
-                );
-
-                // Retry the validation with the new connection
-                rune_etching_has_valid_commit(
-                    bitcoin_client,
-                    ctx,
-                    tx,
-                    rune,
-                    reveal_block_height,
-                    inputs_counter,
-                )
-                .await
-            } else {
-                // Not a connection error, propagate the original error
-                Err(error)
-            }
-        }
-    }
-}
-
 /// Checks if an error indicates a connection issue that requires reconnection
 #[allow(clippy::borrowed_box)]
-fn is_connection_error(error: &Box<dyn std::error::Error + Send + Sync>) -> bool {
+pub fn is_connection_error(error: &Box<dyn std::error::Error + Send + Sync>) -> bool {
     let error_msg = error.to_string().to_lowercase();
 
     // Check for common connection-related error patterns

--- a/components/runes/src/db/cache/rune_validation.rs
+++ b/components/runes/src/db/cache/rune_validation.rs
@@ -93,11 +93,22 @@ pub async fn rune_etching_has_valid_commit(
             }
 
             // Get commit transaction's block height to check confirmation count
-            let commit_tx_height =
-                bitcoind_get_block_height(bitcoin_client, ctx, &commit_tx_info.blockhash.unwrap())?;
+            let Some(blockhash) = commit_tx_info.blockhash else {
+                // Commit transaction not in a block (unconfirmed) - invalid
+                continue;
+            };
+            let commit_tx_height = match bitcoind_get_block_height(bitcoin_client, ctx, &blockhash)
+            {
+                Ok(height) => height,
+                Err(_) => continue,
+            };
 
             // Calculate confirmations and check minimum requirement (6 blocks)
-            let confirmations = reveal_block_height.checked_sub(commit_tx_height).unwrap() + 1;
+            let Some(height_diff) = reveal_block_height.checked_sub(commit_tx_height) else {
+                // Commit transaction is in same block or later than reveal - invalid
+                continue;
+            };
+            let confirmations = height_diff + 1;
             if confirmations >= u32::from(Runestone::COMMIT_CONFIRMATIONS) {
                 return Ok(true);
             }

--- a/components/runes/src/db/cache/rune_validation.rs
+++ b/components/runes/src/db/cache/rune_validation.rs
@@ -211,11 +211,12 @@ mod tests {
     use std::str::FromStr;
 
     use bitcoin::{
-        opcodes, script::Builder, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+        opcodes, script::Builder, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut,
+        Witness,
     };
     use bitcoind::utils::{bitcoind::bitcoind_get_client, Context};
-    use config::BitcoindConfig;
-    use ordinals_parser::Rune;
+    use config::{BitcoindConfig, Config};
+    use ordinals_parser::{Rune, SpacedRune};
 
     use super::*;
 
@@ -682,5 +683,321 @@ mod tests {
 
         // Should succeed because second input has valid commitment
         assert!(result);
+    }
+
+    /// Real-world case: SUPERDOME etching should validate with given heights
+    /// reveal: 910603, commit: 910598 (>= 6 confirmations including commit block)
+    /// txids (for reference):
+    /// reveal 6192cfb67b223dc314a3d3b48a95ee8f41ae32e768bb6c163c0c83339ea993fd
+    /// commit ac45c91190f47b5aeaed46168e66e1782234217c118eff4abba81e2e5347f20c
+    #[tokio::test]
+    async fn test_superdome_commit_validation_succeeds() {
+        let spaced = SpacedRune::from_str("SUPERDOME").unwrap();
+        let rune = spaced.rune;
+
+        // Build a transaction whose tapscript witness includes the rune's commitment
+        let tx = create_transaction_with_valid_commitment(&rune);
+
+        // Mock validation: taproot=true, commit height 910598, reveal height 910603
+        // Confirmations = 910603 - 910598 + 1 = 6 (meets threshold)
+        let result = tx_commits_to_rune_with_mocks(&tx, &rune, 910603, 910598, true)
+            .await
+            .unwrap();
+        assert!(result);
+    }
+
+    /// Ensure that omitted or reserved rune names don't require commit validation
+    /// We simulate this by ensuring the commitment path would fail if called,
+    /// but our higher-level logic should skip calling it entirely for reserved/omitted.
+    #[test]
+    fn test_reserved_or_omitted_rune_commitment_not_required() {
+        // Reserved via omitted name is handled at IndexCache::apply_etching layer, but
+        // here we check the underlying rule: reserved detection works and commitment bytes
+        // are still generated deterministically (not used for validation in reserved path).
+        let reserved = Rune::reserved(840000, 0);
+        assert!(super::is_reserved(&reserved));
+
+        // Named non-reserved like SUPERDOME must not be reserved
+        let named = SpacedRune::from_str("SUPERDOME").unwrap().rune;
+        assert!(!super::is_reserved(&named));
+    }
+
+    // Helper function to create a mock config for testing
+    fn create_mock_config() -> Config {
+        let mut config = Config::test_default();
+        config.bitcoind.network = Network::Regtest;
+        config.runes = Some(config::RunesConfig {
+            lru_cache_size: 1000,
+            db: config::PgDatabaseConfig {
+                dbname: "postgres".to_string(),
+                host: "localhost".to_string(),
+                port: 5432,
+                user: "postgres".to_string(),
+                password: Some("postgres".to_string()),
+                search_path: None,
+                pool_max_size: None,
+            },
+        });
+        config
+    }
+
+    /// Two etchings in the same block - first valid, second invalid
+    /// This tests the scenario where the first etching has valid commitment but the second doesn't
+    #[test]
+    fn test_two_etchings_same_block_first_valid_second_invalid() {
+        let _config = create_mock_config();
+
+        // Create two runes with different characteristics
+        let rune1 = Rune::from_str("TESTRUNEONE").unwrap();
+        let rune2 = Rune::from_str("TESTRUNETWO").unwrap();
+
+        // Verify rune characteristics
+        assert!(!rune1.is_reserved(), "First rune should not be reserved");
+        assert!(!rune2.is_reserved(), "Second rune should not be reserved");
+
+        // Test commit-reveal validation logic
+        let reveal_block = 840100;
+        let commit_block1 = 840094; // 7 confirmations (valid)
+        let commit_block2 = 840095; // 6 confirmations (valid)
+
+        let confirmations1 = reveal_block - commit_block1 + 1;
+        let confirmations2 = reveal_block - commit_block2 + 1;
+
+        assert!(
+            confirmations1 >= 6,
+            "First etching should have sufficient confirmations"
+        );
+        assert!(
+            confirmations2 >= 6,
+            "Second etching should have sufficient confirmations"
+        );
+        assert_eq!(
+            confirmations1, 7,
+            "First etching should have 7 confirmations"
+        );
+        assert_eq!(
+            confirmations2, 6,
+            "Second etching should have 6 confirmations"
+        );
+    }
+
+    /// Two etchings in the same block - both invalid (reserved runes)
+    /// This tests the scenario where both etchings fail validation due to reserved rune names
+    #[test]
+    fn test_two_etchings_same_block_both_invalid_reserved() {
+        // Create two runes with reserved names (which should be invalid)
+        // Using actual reserved rune names that are known to be reserved
+        let rune1 = Rune::from_str("AAAAAAAAAAAAAAAAZOMJMODBYFG").unwrap(); // Reserved rune
+        let rune2 = Rune::from_str("AAAAAAAAAAAAAAAAZOMJMODBYFH").unwrap(); // Another reserved rune
+
+        // Both runes should be reserved and therefore invalid
+        assert!(rune1.is_reserved(), "First rune should be reserved");
+        assert!(rune2.is_reserved(), "Second rune should be reserved");
+
+        // Test commit-reveal validation logic (should fail regardless of confirmations)
+        let reveal_block = 840100;
+        let commit_block1 = 840094;
+        let commit_block2 = 840095;
+
+        let confirmations1 = reveal_block - commit_block1 + 1;
+        let confirmations2 = reveal_block - commit_block2 + 1;
+
+        // Even with sufficient confirmations, reserved runes should be invalid
+        assert!(
+            confirmations1 >= 6,
+            "First etching should have sufficient confirmations"
+        );
+        assert!(
+            confirmations2 >= 6,
+            "Second etching should have sufficient confirmations"
+        );
+        // But the runes themselves are reserved, so they should be invalid
+    }
+
+    /// Two etchings in the same block - both valid
+    /// This tests the scenario where both etchings have valid commitments
+    #[test]
+    fn test_two_etchings_same_block_both_valid() {
+        // Create two runes with valid names
+        let rune1 = Rune::from_str("VALIDRUNEONE").unwrap();
+        let rune2 = Rune::from_str("VALIDRUNETWO").unwrap();
+
+        // Both runes should be non-reserved and therefore potentially valid
+        assert!(!rune1.is_reserved(), "First rune should not be reserved");
+        assert!(!rune2.is_reserved(), "Second rune should not be reserved");
+
+        // Test commit-reveal validation logic
+        let reveal_block = 840100;
+        let commit_block1 = 840094; // 7 confirmations
+        let commit_block2 = 840095; // 6 confirmations
+
+        let confirmations1 = reveal_block - commit_block1 + 1;
+        let confirmations2 = reveal_block - commit_block2 + 1;
+
+        assert!(
+            confirmations1 >= 6,
+            "First etching should have sufficient confirmations"
+        );
+        assert!(
+            confirmations2 >= 6,
+            "Second etching should have sufficient confirmations"
+        );
+        assert_eq!(
+            confirmations1, 7,
+            "First etching should have 7 confirmations"
+        );
+        assert_eq!(
+            confirmations2, 6,
+            "Second etching should have 6 confirmations"
+        );
+    }
+
+    /// Commit-reveal validation with insufficient confirmations
+    /// This tests the scenario where commit_block_height + 5 ≤ reveal_block_height
+    #[test]
+    fn test_commit_reveal_insufficient_confirmations() {
+        // Test the specific rune from the example
+        let rune = Rune::from_str("EWGRWEGBSGRWEGFB").unwrap();
+        assert_eq!(rune.to_string(), "EWGRWEGBSGRWEGFB");
+
+        // Test insufficient confirmations scenario
+        let reveal_block = 874993;
+        let commit_block = 874988; // Only 6 confirmations (874993 - 874988 + 1 = 6)
+        let confirmations = reveal_block - commit_block + 1;
+
+        // This should be exactly sufficient (6 confirmations = 6 required)
+        assert!(confirmations >= 6, "Should have sufficient confirmations");
+        assert_eq!(confirmations, 6, "Should have exactly 6 confirmations");
+
+        // Test insufficient confirmations
+        let insufficient_commit_block = 874989; // Only 5 confirmations (874993 - 874989 + 1 = 5)
+        let insufficient_confirmations = reveal_block - insufficient_commit_block + 1;
+
+        assert!(
+            insufficient_confirmations < 6,
+            "Should have insufficient confirmations"
+        );
+        assert_eq!(
+            insufficient_confirmations, 5,
+            "Should have exactly 5 confirmations"
+        );
+    }
+
+    /// Commit-reveal validation with exactly 6 confirmations
+    /// This tests the scenario where commit_block_height + 5 = reveal_block_height
+    #[test]
+    fn test_commit_reveal_exactly_six_confirmations() {
+        // Calculate confirmations: reveal_block - commit_block + 1 = 105 - 100 + 1 = 6
+        let reveal_block = 105;
+        let commit_block = 100;
+        let confirmations = reveal_block - commit_block + 1;
+
+        assert_eq!(confirmations, 6, "Should have exactly 6 confirmations");
+        assert!(confirmations >= 6, "Should be valid");
+    }
+
+    /// Commit-reveal validation with more than 6 confirmations
+    /// This tests the scenario where there are sufficient confirmations
+    #[test]
+    fn test_commit_reveal_sufficient_confirmations() {
+        // Calculate confirmations: reveal_block - commit_block + 1 = 110 - 100 + 1 = 11
+        let reveal_block = 110;
+        let commit_block = 100;
+        let confirmations = reveal_block - commit_block + 1;
+
+        assert!(confirmations > 6, "Should have more than 6 confirmations");
+        assert_eq!(confirmations, 11, "Should have exactly 11 confirmations");
+    }
+
+    /// Test the specific example from the TODO comment
+    /// This tests the EWGRWEGBSGRWEGFB rune with the specific block heights
+    #[test]
+    fn test_specific_example_ewgrwegsgrwegfb() {
+        // Verify the specific rune name
+        let rune = Rune::from_str("EWGRWEGBSGRWEGFB").unwrap();
+        assert_eq!(rune.to_string(), "EWGRWEGBSGRWEGFB");
+
+        // Test the commit-reveal validation logic
+        // From the example: commit_block = 874948, reveal_block = 874993
+        let commit_block = 874948;
+        let reveal_block = 874993;
+        let confirmations = reveal_block - commit_block + 1;
+
+        // This should be valid (46 confirmations > 6 required)
+        assert!(confirmations >= 6, "Should have sufficient confirmations");
+        assert_eq!(confirmations, 46, "Should have exactly 46 confirmations");
+
+        // Test the invalid case: commit_block = 874948, reveal_block = 874948 (same block)
+        let invalid_commit_block = 874948;
+        let invalid_reveal_block = 874948;
+        let invalid_confirmations = invalid_reveal_block - invalid_commit_block + 1;
+
+        // This should be invalid (1 confirmation < 6 required)
+        assert!(
+            invalid_confirmations < 6,
+            "Should have insufficient confirmations"
+        );
+        assert_eq!(
+            invalid_confirmations, 1,
+            "Should have exactly 1 confirmation"
+        );
+    }
+
+    /// Test edge cases for commit-reveal validation.
+    #[test]
+    fn test_commit_reveal_edge_cases() {
+        // commit_block_height + 5 ≤ reveal_block_height
+        // This should be valid (6 confirmations)
+        let reveal_block = 105;
+        let commit_block = 100;
+        let confirmations = reveal_block - commit_block + 1;
+        assert_eq!(confirmations, 6, "Should have exactly 6 confirmations");
+        assert!(confirmations >= 6, "Should be valid");
+
+        // commit_block_height + 5 = reveal_block_height
+        // This should be valid (6 confirmations)
+        let reveal_block2 = 105;
+        let commit_block2 = 100;
+        let confirmations2 = reveal_block2 - commit_block2 + 1;
+        assert_eq!(confirmations2, 6, "Should have exactly 6 confirmations");
+        assert!(confirmations2 >= 6, "Should be valid");
+
+        // insufficient confirmations
+        let reveal_block3 = 105;
+        let commit_block3 = 101; // Only 5 confirmations
+        let confirmations3 = reveal_block3 - commit_block3 + 1;
+        assert_eq!(confirmations3, 5, "Should have exactly 5 confirmations");
+        assert!(confirmations3 < 6, "Should be invalid");
+
+        // same block (invalid)
+        let reveal_block4 = 105;
+        let commit_block4 = 105; // Same block
+        let confirmations4 = reveal_block4 - commit_block4 + 1;
+        assert_eq!(confirmations4, 1, "Should have exactly 1 confirmation");
+        assert!(confirmations4 < 6, "Should be invalid");
+    }
+
+    /// Test the specific rune names.
+    #[test]
+    fn test_specific_rune_names_from_todo() {
+        let rune = Rune::from_str("EWGRWEGBSGRWEGFB").unwrap();
+        assert_eq!(rune.to_string(), "EWGRWEGBSGRWEGFB");
+        assert!(
+            !rune.is_reserved(),
+            "EWGRWEGBSGRWEGFB should not be reserved"
+        );
+
+        // Test block heights from the example
+        let valid_reveal_block = 874993;
+        let valid_commit_block = 874948;
+        let valid_confirmations = valid_reveal_block - valid_commit_block + 1;
+        assert_eq!(valid_confirmations, 46, "Should have 46 confirmations");
+        assert!(valid_confirmations >= 6, "Should be valid");
+
+        let invalid_reveal_block = 874948;
+        let invalid_commit_block = 874948;
+        let invalid_confirmations = invalid_reveal_block - invalid_commit_block + 1;
+        assert_eq!(invalid_confirmations, 1, "Should have 1 confirmation");
+        assert!(invalid_confirmations < 6, "Should be invalid");
     }
 }

--- a/components/runes/src/db/cache/transaction_cache.rs
+++ b/components/runes/src/db/cache/transaction_cache.rs
@@ -452,6 +452,35 @@ mod test {
     }
 
     #[test]
+    fn etches_rune_with_omitted_name_generates_reserved() {
+        let location = TransactionLocation::dummy();
+        let mut cache = TransactionCache::empty(location.clone());
+        let etching = Etching {
+            divisibility: Some(2),
+            premine: Some(1000),
+            rune: None, // Omitted name → should allocate reserved rune
+            spacers: None,
+            symbol: Some('x'),
+            terms: Some(Terms {
+                amount: Some(1000),
+                cap: None,
+                height: (None, None),
+                offset: (None, None),
+            }),
+            turbo: true,
+        };
+
+        let (_rune_id, db_rune, db_ledger_entry) = cache.apply_etching(&etching, 1);
+
+        // Expected reserved rune string for this location
+        let expected_reserved_name =
+            Rune::reserved(location.block_height, location.tx_index).to_string();
+
+        assert_eq!(db_rune.name, expected_reserved_name);
+        assert_eq!(db_ledger_entry.operation, DbLedgerOperation::Etching);
+    }
+
+    #[test]
     // TODO add cenotaph field to DbRune before filling this in
     fn etches_cenotaph_rune() {
         let location = TransactionLocation::dummy();

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -13,7 +13,7 @@ use bitcoind::{
 };
 use deadpool_postgres::Client;
 use hex;
-use ordinals_parser::{Artifact, Runestone};
+use ordinals_parser::{Artifact, Flaw, Runestone};
 use postgres::pg_begin;
 
 use super::{cache::index_cache::IndexCache, pg_get_max_rune_number, pg_roll_back_block};
@@ -174,25 +174,30 @@ pub async fn index_block(
                     index_cache
                         .apply_cenotaph(&cenotaph, &mut db_tx, ctx, &mut cenotaph_count)
                         .await;
-                    if let Some(etching) = cenotaph.etching {
-                        index_cache
-                            .apply_cenotaph_etching(
-                                &etching,
-                                &mut db_tx,
-                                ctx,
-                                &mut cenotaph_etching_count,
-                            )
-                            .await;
-                    }
-                    if let Some(mint_rune_id) = cenotaph.mint {
-                        index_cache
-                            .apply_cenotaph_mint(
-                                &mint_rune_id,
-                                &mut db_tx,
-                                ctx,
-                                &mut cenotaph_mint_count,
-                            )
-                            .await;
+
+                    if cenotaph.flaw != Some(Flaw::Varint)
+                        && cenotaph.flaw != Some(Flaw::TruncatedField)
+                    {
+                        if let Some(etching) = cenotaph.etching {
+                            index_cache
+                                .apply_cenotaph_etching(
+                                    &etching,
+                                    &mut db_tx,
+                                    ctx,
+                                    &mut cenotaph_etching_count,
+                                )
+                                .await;
+                        }
+                        if let Some(mint_rune_id) = cenotaph.mint {
+                            index_cache
+                                .apply_cenotaph_mint(
+                                    &mint_rune_id,
+                                    &mut db_tx,
+                                    ctx,
+                                    &mut cenotaph_mint_count,
+                                )
+                                .await;
+                        }
                     }
                 }
             }
@@ -258,4 +263,425 @@ pub async fn roll_back_block(pg_client: &mut Client, block_height: u64, ctx: &Co
         "Block {block_height} rolled back in {elapsed:.4}s",
         elapsed = stopwatch.elapsed().as_secs_f32()
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoind::types::{
+        bitcoin::{OutPoint as RosettaOutPoint, TxIn as RosettaTxIn, TxOut as RosettaTxOut},
+        BitcoinBlockData, BitcoinBlockMetadata, BitcoinNetwork, BitcoinTransactionData,
+        BitcoinTransactionMetadata, BlockIdentifier, TransactionIdentifier,
+    };
+    use ordinals_parser::Artifact;
+
+    use super::*;
+
+    fn build_block(block_height: u64, block_hash_hex: &str, timestamp: u32) -> BitcoinBlockData {
+        BitcoinBlockData {
+            block_identifier: BlockIdentifier {
+                hash: format!("0x{}", block_hash_hex.to_lowercase()),
+                index: block_height,
+            },
+            parent_block_identifier: BlockIdentifier {
+                hash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
+                index: block_height - 1,
+            },
+            timestamp,
+            transactions: vec![],
+            metadata: BitcoinBlockMetadata {
+                network: BitcoinNetwork::Mainnet,
+            },
+        }
+    }
+
+    fn build_valid_tx() -> BitcoinTransactionData {
+        // txid: 3a11c5bc4eee38645934607ba63e0d7ac834d399e53c7c06a0ced093a711f1a2
+        let prevout = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0x1cf46d1a3192e5cdcce62441a7a40691ed4f7e34dc97dd3bfc7f96ff2069846e"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 351_058,
+            block_height: 840_000,
+        };
+
+        let inputs = vec![RosettaTxIn {
+            previous_output: prevout,
+            script_sig: "".to_string(),
+            sequence: 5,
+            witness: vec![
+                "77109e8db640d44dd2528f192e9b58754a1178813550e0805aad4b3cbf8c079783f8bf21b2c59ee5713573b6e4f52f3546eac35367a21a0b37d66428d4d14a01".to_string(),
+                "203c7466c6b06e844514e7cfaee750cc3e30b97d0875ebc02e483218c2e0a23e57ac0063036f72645d0927f379cb8bcb678201010118746578742f706c61696e3b636861727365743d7574662d38000e4b4554414d494e454c4f54494f4e68".to_string(),
+                "c03c7466c6b06e844514e7cfaee750cc3e30b97d0875ebc02e483218c2e0a23e57".to_string(),
+            ],
+        }];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - p2tr
+                script_pubkey:
+                    "0x5120f1e73bbd97fd0eac833e781abdbea9c223951aede9e2275ac6c03e8c1b24394b"
+                        .to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 1 - p2tr
+                script_pubkey:
+                    "0x5120f1e73bbd97fd0eac833e781abdbea9c223951aede9e2275ac6c03e8c1b24394b"
+                        .to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 2 - OP_RETURN runestone
+                script_pubkey:
+                    "0x6a5d22020704a7e6e7dbbcf1f2b38203010003800105bded070690c8020a6408aed3191601"
+                        .to_string(),
+                value: 0,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0x3a11c5bc4eee38645934607ba63e0d7ac834d399e53c7c06a0ced093a711f1a2"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 349_966,
+                index: 0,
+            },
+        }
+    }
+
+    fn build_invalid_tx() -> BitcoinTransactionData {
+        // txid: 66d084fe5e206c7183293d1e379caa2011e7750018c65dfd2fd3174ea9f298fc
+        let prevout = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0x871fb5e4042dca1549326da5848bd2257d6e609984a0cfb867e4ff24a56806d0"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 300_000,
+            block_height: 840_000,
+        };
+
+        let inputs = vec![RosettaTxIn {
+            previous_output: prevout,
+            script_sig: "".to_string(),
+            sequence: 4_294_967_293,
+            witness: vec![
+                "558699007abc57d8b87d8ba02a553f08d5b90758a0985fb5c237521dbb0d00e2c66250926de035235078a78aabeb496e087cdfc7553afb43d546fdd9d718dc7c".to_string(),
+                "20ab1fce37e4777d107690082ec5ee6213a2f008ed26602b8c23e49de911ba8b0dac0063074f9a9045bfc47c68".to_string(),
+                "c15976bfaf05d5b1cfbb8927abe2c93cf293edd2cdd408c2ba1ce484eb5621e980".to_string(),
+            ],
+        }];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - OP_RETURN runestone
+                script_pubkey: "0x6a5d1b020304cfb4c2acf497b13e0380068094ebdc030a8094ebdc030801"
+                    .to_string(),
+                value: 0,
+            },
+            RosettaTxOut {
+                // vout 1 - p2wpkh
+                script_pubkey: "0x0014f32b49757996ef8db8d3d029b3dc997560e77d12".to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 2 - p2wpkh
+                script_pubkey: "0x001459966e46ce78b8bf4a54827b84144c82ea21811c".to_string(),
+                value: 15_765,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0x66d084fe5e206c7183293d1e379caa2011e7750018c65dfd2fd3174ea9f298fc"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 283_689,
+                index: 1,
+            },
+        }
+    }
+
+    fn build_no_commit_tx() -> BitcoinTransactionData {
+        // txid: 27bbb1f7776d3ac5f41c17a5cde59b4feba5e9f5c5e76f19559c787a7c771055
+        let prevout0 = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0x99060f5739abacbe53f568723d829cbef21b65d555950cfacf85baf78fc3724d"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 66_600,
+            block_height: 840_000,
+        };
+        let prevout1 = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0x99060f5739abacbe53f568723d829cbef21b65d555950cfacf85baf78fc3724d"
+                    .to_string(),
+            },
+            vout: 1,
+            value: 1_000_410,
+            block_height: 840_000,
+        };
+
+        let inputs = vec![
+            RosettaTxIn {
+                previous_output: prevout0,
+                script_sig: "".to_string(),
+                sequence: 4_294_967_293,
+                witness: vec![
+                    "553d08ee034c7a84b790fb51e05ddffdc07b5ed5fd77774de888190cda69e1b14598194a40a6c6cba669c9e56eb2e95d5f0103a1ce8ee6ed3805a6f9b17fd216".to_string(),
+                ],
+            },
+            RosettaTxIn {
+                previous_output: prevout1,
+                script_sig: "".to_string(),
+                sequence: 4_294_967_293,
+                witness: vec![
+                    "a22561a3a789bd2fdadd5e962d6d402bebe4fe8096a1eb619cba5c8a36eebd00879dd13f698a2b8a9aa19478f6699c300880747082ef8730d4dbadf61631241c".to_string(),
+                ],
+            },
+        ];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - p2tr
+                script_pubkey:
+                    "0x5120f08e113b9485778ef245f751b5fea5ab38fbe93f6a5991eadf90426a8911570b"
+                        .to_string(),
+                value: 419_010,
+            },
+            RosettaTxOut {
+                // vout 1 - OP_RETURN runestone
+                script_pubkey:
+                    "0x6a5d230207049efdc0b9d7cbf3cc1903800105ae4c06d8b9310ab20508b451106012c01f1601"
+                        .to_string(),
+                value: 0,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0x27bbb1f7776d3ac5f41c17a5cde59b4feba5e9f5c5e76f19559c787a7c771055"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 648_000,
+                index: 2,
+            },
+        }
+    }
+
+    #[test]
+    fn valid_and_invalid_etch_output_selection_and_parsing() {
+        // Common block context from the provided fixtures
+        let block = build_block(
+            840_021,
+            "00000000000000000001a6a69ead163c499c0543dcef13c05499a798addb638f",
+            1_713_583_272,
+        );
+
+        let tx_valid = build_valid_tx();
+        let tx_invalid = build_invalid_tx();
+
+        // Valid etch: OP_RETURN is last (vout 2); first eligible should be vout 0
+        let (tx1, eligible1, first_eligible1, total_outputs1) =
+            bitcoin_tx_from_chainhook_tx(&block, &tx_valid);
+        assert_eq!(total_outputs1, 3);
+        assert_eq!(first_eligible1, Some(0));
+        assert!(eligible1.contains_key(&0));
+        assert!(eligible1.contains_key(&1));
+        assert!(!eligible1.contains_key(&2)); // OP_RETURN excluded
+
+        // Invalid etch (by output positioning): OP_RETURN is first (vout 0); first eligible should be vout 1
+        let (tx2, eligible2, first_eligible2, total_outputs2) =
+            bitcoin_tx_from_chainhook_tx(&block, &tx_invalid);
+        assert_eq!(total_outputs2, 3);
+        assert_eq!(first_eligible2, Some(1));
+        assert!(eligible2.contains_key(&1));
+        assert!(eligible2.contains_key(&2));
+        assert!(!eligible2.contains_key(&0)); // OP_RETURN excluded
+
+        // art1: complete etching
+        let art1 = Runestone::decipher(&tx1).expect("runestone");
+        let Artifact::Runestone(rs1) = art1 else {
+            panic!("expected Runestone");
+        };
+        let e1 = rs1.etching.as_ref().expect("expected etching");
+        assert!(
+            e1.divisibility.is_some()
+                && e1.premine.is_some()
+                && e1.terms.is_some()
+                && e1.symbol.is_some()
+                && e1.spacers.is_some()
+                && e1.rune.is_some()
+        );
+
+        // art2: incomplete etching (all optional fields empty, turbo == false)
+        let art2 = Runestone::decipher(&tx2).expect("runestone");
+        let Artifact::Runestone(rs2) = art2 else {
+            // Non-Runestone is acceptable for invalid tx
+            return;
+        };
+        if let Some(e2) = rs2.etching.as_ref() {
+            let is_incomplete = e2.divisibility.is_none()
+                && e2.premine.is_none()
+                && e2.rune.is_none()
+                && e2.spacers.is_none()
+                && e2.symbol.is_none()
+                && e2.terms.is_none()
+                && !e2.turbo;
+            assert!(
+                is_incomplete,
+                "invalid tx should not produce a complete etching"
+            );
+        } else {
+            // No etching at all is also acceptable
+        }
+    }
+
+    #[test]
+    fn invalid_varint_payload_yields_cenotaph_without_etching() {
+        use bitcoin::{absolute::LockTime, script::Builder, transaction::Version, Amount, TxOut};
+
+        // Construct an OP_RETURN | MAGIC_NUMBER script with a single push containing an invalid varint
+        // 19 bytes with MSB set triggers varint error (overflow/truncated)
+        let payload = vec![0x80u8; 19];
+        let push: &bitcoin::script::PushBytes = payload.as_slice().try_into().unwrap();
+        let script = Builder::new()
+            .push_opcode(bitcoin::opcodes::all::OP_RETURN)
+            .push_opcode(ordinals_parser::Runestone::MAGIC_NUMBER)
+            .push_slice(push)
+            .into_script();
+
+        let tx = bitcoin::Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![],
+            output: vec![TxOut {
+                value: Amount::from_sat(0),
+                script_pubkey: script,
+            }],
+        };
+
+        let artifact = ordinals_parser::Runestone::decipher(&tx)
+            .expect("expected Some(Artifact) for malformed runestone");
+        match artifact {
+            ordinals_parser::Artifact::Cenotaph(c) => {
+                // No etching should be present when varint decoding fails
+                assert!(c.etching.is_none());
+            }
+            _ => panic!("expected Cenotaph for invalid varint payload"),
+        }
+    }
+
+    // TODO: add condition to run only if postgres and bitcoind are running
+    #[tokio::test]
+    async fn index_block_writes_valid_rune_and_rejects_invalid() {
+        use config::Config;
+        use ordinals_parser::RuneId;
+        use postgres::{pg_begin, pg_pool, pg_pool_client};
+
+        let ctx = Context::empty();
+
+        // Ensure DB schema exists
+        let mut tokio_pg = crate::db::pg_test_client(true, &ctx).await;
+        // Keep `tokio_pg` alive for the duration of the test so the connection stays open.
+        let _ = &mut tokio_pg;
+
+        // Create a deadpool pool/client for indexer functions
+        let pool = pg_pool(&crate::db::pg_test_config()).expect("pool");
+        let mut client = pg_pool_client(&pool).await.expect("client");
+
+        // Build config and index cache (set defaults to match bitcoin.conf, then allow env overrides)
+        let mut config = Config::test_default();
+        // Defaults from provided bitcoin.conf
+        config.bitcoind.rpc_url = "http://127.0.0.1:8332".to_string();
+        config.bitcoind.rpc_username = "user".to_string();
+        config.bitcoind.rpc_password = "password".to_string();
+        config.bitcoind.network = bitcoin::Network::Bitcoin;
+        // Environment overrides: BTC_RPC_URL, BTC_RPC_USER, BTC_RPC_PASS, BTC_NETWORK
+        if let Ok(url) = std::env::var("BTC_RPC_URL") {
+            config.bitcoind.rpc_url = url;
+        }
+        if let Ok(user) = std::env::var("BTC_RPC_USER") {
+            config.bitcoind.rpc_username = user;
+        }
+        if let Ok(pass) = std::env::var("BTC_RPC_PASS") {
+            config.bitcoind.rpc_password = pass;
+        }
+        if let Ok(net) = std::env::var("BTC_NETWORK") {
+            config.bitcoind.network = match net.to_lowercase().as_str() {
+                "bitcoin" | "mainnet" => bitcoin::Network::Bitcoin,
+                "regtest" => bitcoin::Network::Regtest,
+                "testnet" | "testnet3" | "testnet4" => bitcoin::Network::Testnet,
+                "signet" => bitcoin::Network::Signet,
+                _ => config.bitcoind.network,
+            };
+        }
+        let mut index_cache = IndexCache::new(&config, &pool, &ctx).await;
+        let prometheus = PrometheusMonitoring::new();
+
+        // Build block with all transactions
+        let mut block = build_block(
+            840_021,
+            "00000000000000000001a6a69ead163c499c0543dcef13c05499a798addb638f",
+            1_713_583_272,
+        );
+        let mut tx_valid = build_valid_tx();
+        let mut tx_invalid = build_invalid_tx();
+        let mut tx_no_commit = build_no_commit_tx();
+        tx_valid.metadata.index = 0;
+        tx_invalid.metadata.index = 1;
+        tx_no_commit.metadata.index = 2;
+        block.transactions = vec![tx_valid, tx_invalid, tx_no_commit];
+
+        // Index the block
+        let result =
+            index_block(&mut client, &mut index_cache, &mut block, &prometheus, &ctx).await;
+        // If bitcoind is unreachable, this will Err. Fail fast with context.
+        result.expect("index_block should succeed with reachable bitcoind RPC");
+
+        // Verify DB contents: valid rune present, invalid and no-commit runes absent
+        let mut db_tx = pg_begin(&mut client).await.expect("tx");
+        let valid_id = RuneId::from_str("840021:0").unwrap();
+        let invalid_id = RuneId::from_str("840021:1").unwrap();
+        let no_commit_id = RuneId::from_str("840021:2").unwrap();
+        let valid = crate::db::pg_get_rune_by_id(&valid_id, &mut db_tx, &ctx).await;
+        let invalid = crate::db::pg_get_rune_by_id(&invalid_id, &mut db_tx, &ctx).await;
+        let no_commit = crate::db::pg_get_rune_by_id(&no_commit_id, &mut db_tx, &ctx).await;
+        assert!(valid.is_some(), "valid etch should be inserted into DB");
+        assert!(
+            invalid.is_none(),
+            "invalid etch should not be inserted into DB"
+        );
+        assert!(
+            no_commit.is_none(),
+            "no-commit etch should not be inserted into DB"
+        );
+        db_tx.commit().await.unwrap();
+    }
 }

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -495,6 +495,69 @@ mod tests {
         }
     }
 
+    fn build_rune_wrong_flaw_tx() -> BitcoinTransactionData {
+        // txid: 8bf9d4ec8ed69ae7bac256285b06ae6566cec4679dcfb45b5671a323c2f18c3c
+        let prevout = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0xbd546ac9aa0e275a7f06a960a54db0a9c0de634ad71805cb2d10418b3befc8e8"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 437_000,
+            block_height: 840_020,
+        };
+
+        let inputs = vec![RosettaTxIn {
+            previous_output: prevout,
+            script_sig: "".to_string(),
+            sequence: 4_294_967_293,
+            witness: vec![
+                "059b4e426c21d39a438c0f047c3c724f3bfb69ecfcbc223746cd03a35cdfaf7ea5e4266b6b14153620f8493a4a52a8fef4a9487b86fd1c5d2afca2e93b32573f".to_string(),
+                "200ffc1a61f24b4b064ce03abebdd8de737d1afb5172831315982a3463e37528e9ac00630925d6f33e24da21141068".to_string(),
+                "c1481061324ba36899de17e82ce812d32aa9fd94dd9381afc4fcb7d486b09d2228".to_string(),
+            ],
+        }];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - OP_RETURN runestone
+                script_pubkey:
+                    "0x6a5d20020304a5accff7c3c4f6909420010003a00405b84106a096800ae8070888a401"
+                        .to_string(),
+                value: 0,
+            },
+            RosettaTxOut {
+                // vout 1 - p2tr
+                script_pubkey:
+                    "0x51202b35c0d80bce33fe2036479ab82a4ea60dd760fe2310a433427cc4199da59b8a"
+                        .to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 2 - p2wpkh
+                script_pubkey: "0x00143d71d44fc31fec24a6e3c1e7955e9d388c5ef312".to_string(),
+                value: 22_454,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0x8bf9d4ec8ed69ae7bac256285b06ae6566cec4679dcfb45b5671a323c2f18c3c"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 414_000,
+                index: 3,
+            },
+        }
+    }
+
     #[test]
     fn valid_and_invalid_etch_output_selection_and_parsing() {
         // Common block context from the provided fixtures
@@ -654,10 +717,12 @@ mod tests {
         let mut tx_valid = build_valid_tx();
         let mut tx_invalid = build_invalid_tx();
         let mut tx_no_commit = build_no_commit_tx();
+        let mut tx_rune_wrong_flaw = build_rune_wrong_flaw_tx();
         tx_valid.metadata.index = 0;
         tx_invalid.metadata.index = 1;
         tx_no_commit.metadata.index = 2;
-        block.transactions = vec![tx_valid, tx_invalid, tx_no_commit];
+        tx_rune_wrong_flaw.metadata.index = 3;
+        block.transactions = vec![tx_valid, tx_invalid, tx_no_commit, tx_rune_wrong_flaw];
 
         // Index the block
         let result =
@@ -670,9 +735,12 @@ mod tests {
         let valid_id = RuneId::from_str("840021:0").unwrap();
         let invalid_id = RuneId::from_str("840021:1").unwrap();
         let no_commit_id = RuneId::from_str("840021:2").unwrap();
+        let rune_wrong_flaw_id = RuneId::from_str("840021:3").unwrap();
         let valid = crate::db::pg_get_rune_by_id(&valid_id, &mut db_tx, &ctx).await;
         let invalid = crate::db::pg_get_rune_by_id(&invalid_id, &mut db_tx, &ctx).await;
         let no_commit = crate::db::pg_get_rune_by_id(&no_commit_id, &mut db_tx, &ctx).await;
+        let rune_wrong_flaw =
+            crate::db::pg_get_rune_by_id(&rune_wrong_flaw_id, &mut db_tx, &ctx).await;
         assert!(valid.is_some(), "valid etch should be inserted into DB");
         assert!(
             invalid.is_none(),
@@ -681,6 +749,10 @@ mod tests {
         assert!(
             no_commit.is_none(),
             "no-commit etch should not be inserted into DB"
+        );
+        assert!(
+            rune_wrong_flaw.is_some(),
+            "cenotaph rune etch should be inserted into DB"
         );
         db_tx.commit().await.unwrap();
     }

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -1,23 +1,24 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, str::FromStr};
 
 use bitcoin::{
     absolute::LockTime,
-    transaction::{TxOut, Version},
-    Amount, Network, ScriptBuf, Transaction,
+    blockdata::witness::Witness,
+    transaction::{OutPoint, Sequence, TxIn, TxOut, Version},
+    Amount, Network, ScriptBuf, Transaction, Txid,
 };
 use bitcoind::{
-    try_error, try_info, try_warn,
+    try_info,
     types::{BitcoinBlockData, BitcoinTransactionData},
     utils::Context,
 };
 use deadpool_postgres::Client;
+use hex;
 use ordinals_parser::{Artifact, Runestone};
 use postgres::pg_begin;
 
 use super::{cache::index_cache::IndexCache, pg_get_max_rune_number, pg_roll_back_block};
 use crate::{
-    db::cache::{rune_validation::is_connection_error, transaction_location::TransactionLocation},
-    utils::monitoring::PrometheusMonitoring,
+    db::cache::transaction_location::TransactionLocation, utils::monitoring::PrometheusMonitoring,
 };
 
 pub fn get_rune_genesis_block_height(network: Network) -> u64 {
@@ -36,6 +37,7 @@ fn bitcoin_tx_from_chainhook_tx(
     block: &BitcoinBlockData,
     tx: &BitcoinTransactionData,
 ) -> (Transaction, HashMap<u32, ScriptBuf>, Option<u32>, u32) {
+    let mut inputs = Vec::with_capacity(tx.metadata.inputs.len());
     let mut outputs = Vec::with_capacity(tx.metadata.outputs.len());
     let mut eligible_outputs = HashMap::new();
     let mut first_eligible_output: Option<u32> = None;
@@ -52,12 +54,37 @@ fn bitcoin_tx_from_chainhook_tx(
             script_pubkey: script,
         });
     }
+    for input in tx.metadata.inputs.iter() {
+        // Convert hex strings to bytes for witness data
+        let witness_bytes: Vec<Vec<u8>> = input
+            .witness
+            .iter()
+            .map(|hex_str| {
+                // Remove "0x" prefix and decode hex string to bytes
+                let clean_hex = if hex_str.starts_with("0x") {
+                    &hex_str[2..]
+                } else {
+                    hex_str
+                };
+                hex::decode(clean_hex).unwrap_or_default()
+            })
+            .collect();
+
+        inputs.push(TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_str(&input.previous_output.txid.hash[2..]).unwrap(),
+                vout: input.previous_output.vout,
+            },
+            script_sig: ScriptBuf::new(), // Unused
+            sequence: Sequence(input.sequence),
+            witness: Witness::from_slice(&witness_bytes),
+        });
+    }
     (
         Transaction {
             version: Version::TWO,
             lock_time: LockTime::from_time(block.timestamp).unwrap(),
-            // Inputs don't matter for Runestone parsing.
-            input: vec![],
+            input: inputs,
             output: outputs,
         },
         eligible_outputs,
@@ -73,7 +100,7 @@ pub async fn index_block(
     block: &mut BitcoinBlockData,
     prometheus: &PrometheusMonitoring,
     ctx: &Context,
-) {
+) -> Result<(), String> {
     let stopwatch = std::time::Instant::now();
     let block_hash = &block.block_identifier.hash;
     let block_height = block.block_identifier.index;
@@ -125,7 +152,7 @@ pub async fn index_block(
                         .apply_runestone(&runestone, &mut db_tx, ctx)
                         .await;
                     if let Some(etching) = runestone.etching {
-                        if let Err(err) = index_cache
+                        index_cache
                             .apply_etching(
                                 &etching,
                                 &mut db_tx,
@@ -134,34 +161,7 @@ pub async fn index_block(
                                 &transaction,
                                 &mut inputs_count,
                             )
-                            .await
-                        {
-                            // Only reconnect and retry on connection-related errors
-                            if is_connection_error(&err) {
-                                try_warn!(ctx, "Bitcoin RPC connection error detected: {}", err);
-                                index_cache.reconnect_bitcoin_client(ctx);
-                                if let Err(err) = index_cache
-                                    .apply_etching(
-                                        &etching,
-                                        &mut db_tx,
-                                        ctx,
-                                        &mut etching_count,
-                                        &transaction,
-                                        &mut inputs_count,
-                                    )
-                                    .await
-                                {
-                                    try_error!(
-                                        ctx,
-                                        "apply_etching failed twice after reconnect: {}",
-                                        err
-                                    );
-                                }
-                            } else {
-                                // Non-connection errors: propagate error
-                                try_error!(ctx, "apply_etching failed: {}", err);
-                            }
-                        }
+                            .await?;
                     }
                     if let Some(mint_rune_id) = runestone.mint {
                         index_cache
@@ -240,6 +240,8 @@ pub async fn index_block(
         "RunesIndexer indexed block #{block_height}: {etching_count} etchings, {mint_count} mints, {edict_count} edicts, {cenotaph_count} cenotaphs ({cenotaph_etching_count} etchings, {cenotaph_mint_count} mints) in {}s",
         elapsed.as_secs_f32()
     );
+
+    Ok(())
 }
 
 /// Roll back a Bitcoin block because of a re-org.

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -6,7 +6,7 @@ use bitcoin::{
     Amount, Network, ScriptBuf, Transaction,
 };
 use bitcoind::{
-    try_info,
+    try_error, try_info, try_warn,
     types::{BitcoinBlockData, BitcoinTransactionData},
     utils::Context,
 };
@@ -16,7 +16,8 @@ use postgres::pg_begin;
 
 use super::{cache::index_cache::IndexCache, pg_get_max_rune_number, pg_roll_back_block};
 use crate::{
-    db::cache::transaction_location::TransactionLocation, utils::monitoring::PrometheusMonitoring,
+    db::cache::{rune_validation::is_connection_error, transaction_location::TransactionLocation},
+    utils::monitoring::PrometheusMonitoring,
 };
 
 pub fn get_rune_genesis_block_height(network: Network) -> u64 {
@@ -124,7 +125,7 @@ pub async fn index_block(
                         .apply_runestone(&runestone, &mut db_tx, ctx)
                         .await;
                     if let Some(etching) = runestone.etching {
-                        index_cache
+                        if let Err(err) = index_cache
                             .apply_etching(
                                 &etching,
                                 &mut db_tx,
@@ -133,7 +134,34 @@ pub async fn index_block(
                                 &transaction,
                                 &mut inputs_count,
                             )
-                            .await;
+                            .await
+                        {
+                            // Only reconnect and retry on connection-related errors
+                            if is_connection_error(&err) {
+                                try_warn!(ctx, "Bitcoin RPC connection error detected: {}", err);
+                                index_cache.reconnect_bitcoin_client(ctx);
+                                if let Err(err) = index_cache
+                                    .apply_etching(
+                                        &etching,
+                                        &mut db_tx,
+                                        ctx,
+                                        &mut etching_count,
+                                        &transaction,
+                                        &mut inputs_count,
+                                    )
+                                    .await
+                                {
+                                    try_error!(
+                                        ctx,
+                                        "apply_etching failed twice after reconnect: {}",
+                                        err
+                                    );
+                                }
+                            } else {
+                                // Non-connection errors: propagate error
+                                try_error!(ctx, "apply_etching failed: {}", err);
+                            }
+                        }
                     }
                     if let Some(mint_rune_id) = runestone.mint {
                         index_cache

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -85,6 +85,7 @@ pub async fn index_block(
     let mut cenotaph_etching_count: u64 = 0;
     let mut cenotaph_mint_count: u64 = 0;
     let mut cenotaph_count: u64 = 0;
+    let mut inputs_count: u64 = 0;
 
     let mut db_tx = pg_begin(pg_client).await.unwrap();
     index_cache.reset_max_rune_number(&mut db_tx).await;
@@ -124,7 +125,14 @@ pub async fn index_block(
                         .await;
                     if let Some(etching) = runestone.etching {
                         index_cache
-                            .apply_etching(&etching, &mut db_tx, ctx, &mut etching_count)
+                            .apply_etching(
+                                &etching,
+                                &mut db_tx,
+                                ctx,
+                                &mut etching_count,
+                                &transaction,
+                                &mut inputs_count,
+                            )
                             .await;
                     }
                     if let Some(mint_rune_id) = runestone.mint {
@@ -189,7 +197,7 @@ pub async fn index_block(
     prometheus.metrics_record_runes_cenotaph_per_block(cenotaph_count);
     prometheus.metrics_record_runes_cenotaph_etching_per_block(cenotaph_etching_count);
     prometheus.metrics_record_runes_cenotaph_mint_per_block(cenotaph_mint_count);
-
+    prometheus.metrics_record_runes_etching_inputs_checked_per_block(inputs_count);
     // Record metrics
     prometheus.metrics_block_indexed(block_height);
     let current_rune_number = pg_get_max_rune_number(pg_client).await;

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -61,11 +61,7 @@ fn bitcoin_tx_from_chainhook_tx(
             .iter()
             .map(|hex_str| {
                 // Remove "0x" prefix and decode hex string to bytes
-                let clean_hex = if hex_str.starts_with("0x") {
-                    &hex_str[2..]
-                } else {
-                    hex_str
-                };
+                let clean_hex = hex_str.strip_prefix("0x").unwrap_or(hex_str.as_str());
                 hex::decode(clean_hex).unwrap_or_default()
             })
             .collect();

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -849,6 +849,7 @@ mod tests {
 
     // TODO: add condition to run only if postgres and bitcoind are running
     #[tokio::test]
+    #[ignore]
     async fn index_block_writes_valid_rune_and_rejects_invalid() {
         use config::Config;
         use ordinals_parser::RuneId;

--- a/components/runes/src/db/index.rs
+++ b/components/runes/src/db/index.rs
@@ -175,9 +175,7 @@ pub async fn index_block(
                         .apply_cenotaph(&cenotaph, &mut db_tx, ctx, &mut cenotaph_count)
                         .await;
 
-                    if cenotaph.flaw != Some(Flaw::Varint)
-                        && cenotaph.flaw != Some(Flaw::TruncatedField)
-                    {
+                    if cenotaph.flaw != Some(Flaw::Varint) {
                         if let Some(etching) = cenotaph.etching {
                             index_cache
                                 .apply_cenotaph_etching(
@@ -185,8 +183,10 @@ pub async fn index_block(
                                     &mut db_tx,
                                     ctx,
                                     &mut cenotaph_etching_count,
+                                    &transaction,
+                                    &mut inputs_count,
                                 )
-                                .await;
+                                .await?;
                         }
                         if let Some(mint_rune_id) = cenotaph.mint {
                             index_cache
@@ -558,6 +558,192 @@ mod tests {
         }
     }
 
+    fn build_internetgold_tx() -> BitcoinTransactionData {
+        // txid: 66d084fe5e206c7183293d1e379caa2011e7750018c65dfd2fd3174ea9f298fc
+        // This is the INTERNETGOLD transaction with truncated LEB128 field
+        let prevout = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0x871fb5e4042dca1549326da5848bd2257d6e609984a0cfb867e4ff24a56806d0"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 300_000,
+            block_height: 840_020,
+        };
+
+        let inputs = vec![RosettaTxIn {
+            previous_output: prevout,
+            script_sig: "".to_string(),
+            sequence: 4_294_967_293,
+            witness: vec![
+                "558699007abc57d8b87d8ba02a553f08d5b90758a0985fb5c237521dbb0d00e2c66250926de035235078a78aabeb496e087cdfc7553afb43d546fdd9d718dc7c".to_string(),
+                "20ab1fce37e4777d107690082ec5ee6213a2f008ed26602b8c23e49de911ba8b0dac0063074f9a9045bfc47c68".to_string(),
+                "c15976bfaf05d5b1cfbb8927abe2c93cf293edd2cdd408c2ba1ce484eb5621e980".to_string(),
+            ],
+        }];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - OP_RETURN runestone with truncated LEB128
+                script_pubkey: "0x6a5d1b020304cfb4c2acf497b13e0380068094ebdc030a8094ebdc030801"
+                    .to_string(),
+                value: 0,
+            },
+            RosettaTxOut {
+                // vout 1 - p2wpkh
+                script_pubkey: "0x0014f32b49757996ef8db8d3d029b3dc997560e77d12".to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 2 - p2wpkh
+                script_pubkey: "0x001459966e46ce78b8bf4a54827b84144c82ea21811c".to_string(),
+                value: 15_765,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0x66d084fe5e206c7183293d1e379caa2011e7750018c65dfd2fd3174ea9f298fc"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 283_689,
+                index: 3,
+            },
+        }
+    }
+
+    fn build_elonmuskdoge_tx() -> BitcoinTransactionData {
+        // txid: 89e8149d38f8b702621fa18310b10794e541c0b52478466b85f156f5622b8fe3
+        // This is the ELONMUSKDOGE transaction
+        let prevout = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0xde6c56ecf9212e8946c71267108cce91ccc71d378b55aa6a1f41a3d93a82e8cb"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 407_000,
+            block_height: 840_020,
+        };
+
+        let inputs = vec![RosettaTxIn {
+            previous_output: prevout,
+            script_sig: "".to_string(),
+            sequence: 4_294_967_293,
+            witness: vec![
+                "ee500cbe575753f98e50b67c20d53226daa08a12b81e4ec4fb47931b036b41238d586965080356f57ee7526f80774050056dd0bb09fc1d4169151d895d30802a".to_string(),
+                "20f06ac7775ba12c567125ad1378251e934aa8d3411a9221f6b2c6c1cb6cfa3a3fac00630746f33f8d50844768".to_string(),
+                "c1695fa445b5b9df8ba12a08a6afc6e6dac5bd962f8df317da08c57142d7c8f41b".to_string(),
+            ],
+        }];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - OP_RETURN runestone
+                script_pubkey:
+                    "0x6a5d1f020304c6e6ffe9888ae1230300054506a096800ac0de810a08e80710f2a233"
+                        .to_string(),
+                value: 0,
+            },
+            RosettaTxOut {
+                // vout 1 - p2wpkh
+                script_pubkey: "0x001426909c2c3de5de4b6eccb8c0f65ab209fe6f4720".to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 2 - p2wpkh
+                script_pubkey: "0x001406f10a8f6a0aec21e97e02913f0b39f9aa477bbf".to_string(),
+                value: 20_454,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0x89e8149d38f8b702621fa18310b10794e541c0b52478466b85f156f5622b8fe3"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 386_000,
+                index: 4,
+            },
+        }
+    }
+
+    fn build_whataremfers_tx() -> BitcoinTransactionData {
+        // txid: c075c5eba59ca77c40085fc417c8adafa9d2c9970158c7311d60fb24e00d4b45
+        // This is the WHATAREMFERS transaction
+        let prevout = RosettaOutPoint {
+            txid: TransactionIdentifier {
+                hash: "0xee637d9afdaabd9d5fb64fb8bb0396b69b12c6d1f150a00a9692f3bc09c5f6e5"
+                    .to_string(),
+            },
+            vout: 0,
+            value: 304_000,
+            block_height: 840_020,
+        };
+
+        let inputs = vec![RosettaTxIn {
+            previous_output: prevout,
+            script_sig: "".to_string(),
+            sequence: 4_294_967_293,
+            witness: vec![
+                "541ffd18ea22d83e45332caaf82b4bcfc28117fd97f9430caacf3553306e77df600fd2f439380d53ce848e2d6f9c22cf3ef5729ef557f8d2ba28c8dafe3a8e8c".to_string(),
+                "20df9be78e98eaac880ca35fea0f4311832c7a03ad6a2fb1224075a1802267f1f9ac006308fae3bd5c87f52f0168".to_string(),
+                "c0553bd58d975c1a22280e79d06fd5e7fc8618ef46dc56c43f777da6f8800cbb62".to_string(),
+            ],
+        }];
+
+        let outputs = vec![
+            RosettaTxOut {
+                // vout 0 - OP_RETURN runestone
+                script_pubkey: "0x6a5d24020304fac7f7e5f5b0fd97010348054d06a096800a904e0880b191640ca089310ec0843d"
+                    .to_string(),
+                value: 0,
+            },
+            RosettaTxOut {
+                // vout 1 - p2tr
+                script_pubkey: "0x512078a95794567c472013bfac2ecf3e8090e847f7bfd69748613bc0bf6c28be1549"
+                    .to_string(),
+                value: 546,
+            },
+            RosettaTxOut {
+                // vout 2 - p2wpkh
+                script_pubkey: "0x0014a4c6356a3723f8cc900f9b6cbe761f8937917af5"
+                    .to_string(),
+                value: 16_283,
+            },
+        ];
+
+        BitcoinTransactionData {
+            transaction_identifier: TransactionIdentifier {
+                hash: "0xc075c5eba59ca77c40085fc417c8adafa9d2c9970158c7311d60fb24e00d4b45"
+                    .to_string(),
+            },
+            operations: vec![],
+            metadata: BitcoinTransactionMetadata {
+                inputs,
+                outputs,
+                ordinal_operations: vec![],
+                brc20_operation: None,
+                proof: None,
+                fee: 287_171,
+                index: 5,
+            },
+        }
+    }
+
     #[test]
     fn valid_and_invalid_etch_output_selection_and_parsing() {
         // Common block context from the provided fixtures
@@ -718,11 +904,25 @@ mod tests {
         let mut tx_invalid = build_invalid_tx();
         let mut tx_no_commit = build_no_commit_tx();
         let mut tx_rune_wrong_flaw = build_rune_wrong_flaw_tx();
+        let mut tx_internetgold = build_internetgold_tx();
+        let mut tx_elonmuskdoge = build_elonmuskdoge_tx();
+        let mut tx_whataremfers = build_whataremfers_tx();
         tx_valid.metadata.index = 0;
         tx_invalid.metadata.index = 1;
         tx_no_commit.metadata.index = 2;
         tx_rune_wrong_flaw.metadata.index = 3;
-        block.transactions = vec![tx_valid, tx_invalid, tx_no_commit, tx_rune_wrong_flaw];
+        tx_internetgold.metadata.index = 4;
+        tx_elonmuskdoge.metadata.index = 5;
+        tx_whataremfers.metadata.index = 6;
+        block.transactions = vec![
+            tx_valid,
+            tx_invalid,
+            tx_no_commit,
+            tx_rune_wrong_flaw,
+            tx_internetgold,
+            tx_elonmuskdoge,
+            tx_whataremfers,
+        ];
 
         // Index the block
         let result =
@@ -736,11 +936,17 @@ mod tests {
         let invalid_id = RuneId::from_str("840021:1").unwrap();
         let no_commit_id = RuneId::from_str("840021:2").unwrap();
         let rune_wrong_flaw_id = RuneId::from_str("840021:3").unwrap();
+        let internetgold_id = RuneId::from_str("840021:4").unwrap();
+        let elonmuskdoge_id = RuneId::from_str("840021:5").unwrap();
+        let whataremfers_id = RuneId::from_str("840021:6").unwrap();
         let valid = crate::db::pg_get_rune_by_id(&valid_id, &mut db_tx, &ctx).await;
         let invalid = crate::db::pg_get_rune_by_id(&invalid_id, &mut db_tx, &ctx).await;
         let no_commit = crate::db::pg_get_rune_by_id(&no_commit_id, &mut db_tx, &ctx).await;
         let rune_wrong_flaw =
             crate::db::pg_get_rune_by_id(&rune_wrong_flaw_id, &mut db_tx, &ctx).await;
+        let internetgold = crate::db::pg_get_rune_by_id(&internetgold_id, &mut db_tx, &ctx).await;
+        let elonmuskdoge = crate::db::pg_get_rune_by_id(&elonmuskdoge_id, &mut db_tx, &ctx).await;
+        let whataremfers = crate::db::pg_get_rune_by_id(&whataremfers_id, &mut db_tx, &ctx).await;
         assert!(valid.is_some(), "valid etch should be inserted into DB");
         assert!(
             invalid.is_none(),
@@ -753,6 +959,18 @@ mod tests {
         assert!(
             rune_wrong_flaw.is_some(),
             "cenotaph rune etch should be inserted into DB"
+        );
+        assert!(
+            internetgold.is_none(),
+            "INTERNETGOLD etch should not be inserted into DB"
+        );
+        assert!(
+            elonmuskdoge.is_none(),
+            "ELONMUSKDOGE etch should not be inserted into DB"
+        );
+        assert!(
+            whataremfers.is_none(),
+            "WHATAREMFERS etch should not be inserted into DB"
         );
         db_tx.commit().await.unwrap();
     }

--- a/components/runes/src/db/mod.rs
+++ b/components/runes/src/db/mod.rs
@@ -69,6 +69,7 @@ pub async fn pg_insert_runes(
             &row.terms_offset_start,
             &row.terms_offset_end,
             &row.turbo,
+            &row.cenotaph,
             &row.timestamp,
         ];
 
@@ -76,10 +77,10 @@ pub async fn pg_insert_runes(
             .query(
                 "INSERT INTO runes \
                    (id, number, name, spaced_name, block_hash, block_height, tx_index, tx_id, divisibility, premine, symbol, \
-                    terms_amount, terms_cap, terms_height_start, terms_height_end, terms_offset_start, terms_offset_end, turbo, timestamp) \
+                    terms_amount, terms_cap, terms_height_start, terms_height_end, terms_offset_start, terms_offset_end, turbo, cenotaph, timestamp) \
                  SELECT \
                    $1, (SELECT COALESCE(MAX(number), 0) + 1 FROM runes), $2, $3, $4, $5, $6, $7, $8, $9, $10, \
-                   $11, $12, $13, $14, $15, $16, $17, $18 \
+                   $11, $12, $13, $14, $15, $16, $17, $18, $19 \
                  WHERE NOT EXISTS (SELECT 1 FROM runes WHERE name = $2) \
                  ON CONFLICT (name) DO NOTHING",
                 &params,

--- a/components/runes/src/db/mod.rs
+++ b/components/runes/src/db/mod.rs
@@ -50,58 +50,45 @@ pub async fn pg_insert_runes(
     db_tx: &mut Transaction<'_>,
     ctx: &Context,
 ) -> Result<bool, Error> {
-    for chunk in rows.chunks(500) {
-        let mut arg_num = 1;
-        let mut arg_str = String::new();
-        let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
-        for row in chunk.iter() {
-            arg_str.push('(');
-            for i in 0..18 {
-                arg_str.push_str(format!("${},", arg_num + i).as_str());
-            }
-            arg_str.pop();
-            arg_str.push_str("),");
-            arg_num += 18;
-            params.push(&row.id);
-            params.push(&row.name);
-            params.push(&row.spaced_name);
-            params.push(&row.block_hash);
-            params.push(&row.block_height);
-            params.push(&row.tx_index);
-            params.push(&row.tx_id);
-            params.push(&row.divisibility);
-            params.push(&row.premine);
-            params.push(&row.symbol);
-            params.push(&row.terms_amount);
-            params.push(&row.terms_cap);
-            params.push(&row.terms_height_start);
-            params.push(&row.terms_height_end);
-            params.push(&row.terms_offset_start);
-            params.push(&row.terms_offset_end);
-            params.push(&row.turbo);
-            params.push(&row.timestamp);
-        }
-        arg_str.pop();
+    for row in rows.iter() {
+        let params: Vec<&(dyn ToSql + Sync)> = vec![
+            &row.id,
+            &row.name,
+            &row.spaced_name,
+            &row.block_hash,
+            &row.block_height,
+            &row.tx_index,
+            &row.tx_id,
+            &row.divisibility,
+            &row.premine,
+            &row.symbol,
+            &row.terms_amount,
+            &row.terms_cap,
+            &row.terms_height_start,
+            &row.terms_height_end,
+            &row.terms_offset_start,
+            &row.terms_offset_end,
+            &row.turbo,
+            &row.timestamp,
+        ];
 
-        match db_tx
+        if let Err(e) = db_tx
             .query(
-            " INSERT INTO runes 
-                    (id, number, name, spaced_name, block_hash, block_height, tx_index, tx_id, divisibility, premine, symbol,
-                    terms_amount, terms_cap, terms_height_start, terms_height_end, terms_offset_start, terms_offset_end, turbo,
-                    timestamp) VALUES 
-                        ($1, (SELECT COALESCE(MAX(number), 0) + 1 FROM runes), $2, $3, $4, $5, $6, $7, $8, $9, $10,
-                        $11, $12, $13, $14, $15, $16, $17, $18)
-                    ON CONFLICT (name) DO NOTHING",
+                "INSERT INTO runes \
+                   (id, number, name, spaced_name, block_hash, block_height, tx_index, tx_id, divisibility, premine, symbol, \
+                    terms_amount, terms_cap, terms_height_start, terms_height_end, terms_offset_start, terms_offset_end, turbo, timestamp) \
+                 SELECT \
+                   $1, (SELECT COALESCE(MAX(number), 0) + 1 FROM runes), $2, $3, $4, $5, $6, $7, $8, $9, $10, \
+                   $11, $12, $13, $14, $15, $16, $17, $18 \
+                 WHERE NOT EXISTS (SELECT 1 FROM runes WHERE name = $2) \
+                 ON CONFLICT (name) DO NOTHING",
                 &params,
             )
             .await
         {
-            Ok(_) => {}
-            Err(e) => {
-                try_error!(ctx, "Error inserting runes: {:?}", e);
-                process::exit(1);
-            }
-        };
+            try_error!(ctx, "Error inserting rune: {:?}", e);
+            process::exit(1);
+        }
     }
     Ok(true)
 }

--- a/components/runes/src/db/mod.rs
+++ b/components/runes/src/db/mod.rs
@@ -56,14 +56,13 @@ pub async fn pg_insert_runes(
         let mut params: Vec<&(dyn ToSql + Sync)> = vec![];
         for row in chunk.iter() {
             arg_str.push('(');
-            for i in 0..19 {
+            for i in 0..18 {
                 arg_str.push_str(format!("${},", arg_num + i).as_str());
             }
             arg_str.pop();
             arg_str.push_str("),");
-            arg_num += 19;
+            arg_num += 18;
             params.push(&row.id);
-            params.push(&row.number);
             params.push(&row.name);
             params.push(&row.spaced_name);
             params.push(&row.block_hash);
@@ -83,13 +82,16 @@ pub async fn pg_insert_runes(
             params.push(&row.timestamp);
         }
         arg_str.pop();
+
         match db_tx
             .query(
-                &format!("INSERT INTO runes
+            " INSERT INTO runes 
                     (id, number, name, spaced_name, block_hash, block_height, tx_index, tx_id, divisibility, premine, symbol,
                     terms_amount, terms_cap, terms_height_start, terms_height_end, terms_offset_start, terms_offset_end, turbo,
-                    timestamp) VALUES {}
-                    ON CONFLICT (name) DO NOTHING", arg_str),
+                    timestamp) VALUES 
+                        ($1, (SELECT COALESCE(MAX(number), 0) + 1 FROM runes), $2, $3, $4, $5, $6, $7, $8, $9, $10,
+                        $11, $12, $13, $14, $15, $16, $17, $18)
+                    ON CONFLICT (name) DO NOTHING",
                 &params,
             )
             .await

--- a/components/runes/src/lib.rs
+++ b/components/runes/src/lib.rs
@@ -51,7 +51,8 @@ async fn new_runes_indexer_runloop(
                 #[cfg(feature = "dhat-heap")]
                 let _profiler = dhat::Profiler::new_heap();
 
-                let mut index_cache = IndexCache::new(&config_moved, &pg_pool_moved).await;
+                let mut index_cache =
+                    IndexCache::new(&config_moved, &pg_pool_moved, &ctx_moved).await;
                 loop {
                     if abort_signal_moved.load(Ordering::SeqCst) {
                         break;

--- a/components/runes/src/lib.rs
+++ b/components/runes/src/lib.rs
@@ -86,7 +86,7 @@ async fn new_runes_indexer_runloop(
                                         &prometheus_moved,
                                         &ctx_moved,
                                     )
-                                    .await;
+                                    .await?;
                                 }
                             }
                             IndexerCommand::Terminate => {

--- a/components/runes/src/utils/monitoring.rs
+++ b/components/runes/src/utils/monitoring.rs
@@ -40,6 +40,7 @@ pub struct PrometheusMonitoring {
     pub runes_cenotaph_operations_per_block: UInt64Gauge,
     pub runes_cenotaph_etching_operations_per_block: UInt64Gauge,
     pub runes_cenotaph_mint_operations_per_block: UInt64Gauge,
+    pub runes_etching_inputs_checked_per_block: UInt64Gauge,
 
     // Registry
     pub registry: Registry,
@@ -137,6 +138,11 @@ impl PrometheusMonitoring {
             "runes_cenotaph_mint_operations_per_block",
             "Number of cenotaph Runes mints processed per block",
         );
+        let runes_etching_inputs_checked_per_block = Self::create_and_register_uint64_gauge(
+            &registry,
+            "runes_etching_inputs_checked_per_block",
+            "Number of inputs checked for rune commitment per block",
+        );
 
         PrometheusMonitoring {
             last_indexed_block_height,
@@ -152,6 +158,7 @@ impl PrometheusMonitoring {
             runes_cenotaph_operations_per_block,
             runes_cenotaph_etching_operations_per_block,
             runes_cenotaph_mint_operations_per_block,
+            runes_etching_inputs_checked_per_block,
             registry,
         }
     }
@@ -265,6 +272,10 @@ impl PrometheusMonitoring {
     pub fn metrics_record_runes_cenotaph_mint_per_block(&self, cenotaph_mint_count: u64) {
         self.runes_cenotaph_mint_operations_per_block
             .set(cenotaph_mint_count);
+    }
+    pub fn metrics_record_runes_etching_inputs_checked_per_block(&self, inputs_count: u64) {
+        self.runes_etching_inputs_checked_per_block
+            .set(inputs_count);
     }
 }
 
@@ -749,4 +760,6 @@ mod tests {
             "Highest rune number indexed should be 100"
         );
     }
+
+    // TODO: add test for runes_etching_inputs_checked_per_block
 }

--- a/components/runes/src/utils/monitoring.rs
+++ b/components/runes/src/utils/monitoring.rs
@@ -761,5 +761,32 @@ mod tests {
         );
     }
 
-    // TODO: add test for runes_etching_inputs_checked_per_block
+    #[test]
+    fn test_runes_etching_inputs_checked_per_block_metric() {
+        let monitoring = PrometheusMonitoring::new();
+
+        // Record inputs checked for different blocks
+        monitoring.metrics_record_runes_etching_inputs_checked_per_block(5);
+        monitoring.metrics_record_runes_etching_inputs_checked_per_block(10);
+        monitoring.metrics_record_runes_etching_inputs_checked_per_block(3);
+
+        // Get the gauge values using the registry
+        let metrics = monitoring.registry.gather();
+
+        // Find the runes_etching_inputs_checked_per_block metric
+        let metric_family = metrics
+            .iter()
+            .find(|mf| mf.get_name() == "runes_etching_inputs_checked_per_block")
+            .expect("Should find runes_etching_inputs_checked_per_block metric");
+
+        let metric = metric_family.get_metric().first().unwrap();
+        let gauge = metric.get_gauge();
+
+        // Verify the gauge value (should be the last value set)
+        assert_eq!(
+            gauge.get_value(),
+            3.0,
+            "Should have recorded 3 as the last value"
+        );
+    }
 }


### PR DESCRIPTION
Invalidate runes that do not have the etching_commit at least 5 blocks before the etching_reveal.